### PR TITLE
feat: multi-account support with combined usage dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ A native macOS menu bar app for monitoring your [ZhiPu (智谱)](https://open.bi
 
 ## Features
 
+- **Multi-Account Support** — Configure multiple named API accounts in settings
+- **Combined + Per-Account View** — See merged totals and each account's usage together
+- **Partial Failure Tolerance** — One failing account no longer blocks others from displaying
 - **Quota Monitoring** — Track token and MCP usage quotas with visual progress bars and color-coded warnings (green/orange/red)
 - **Model Usage** — View total token consumption and model call counts over the last 24 hours
 - **Tool Usage** — See per-model tool call breakdowns
@@ -31,18 +34,37 @@ swift run
 
 Or open `Package.swift` in Xcode and press Cmd+R.
 
+### Build Signed App Bundle
+
+To keep a stable app identity (important for avoiding repeated Keychain prompts), build the `.app` bundle with a real signing certificate:
+
+```bash
+cd ZaiUsageMenuBar
+security find-identity -v -p codesigning
+SIGNING_IDENTITY="Apple Development: Your Name (TEAMID)" ./build-app.sh
+open .build/release/ZaiUsageMenuBar.app
+```
+
+If you intentionally want ad-hoc signing for local experiments only:
+
+```bash
+cd ZaiUsageMenuBar
+ALLOW_ADHOC_SIGNING=1 ./build-app.sh
+```
+
 ## Configuration
 
 1. Click the **gear icon** in the popover header
-2. Paste your ZhiPu API auth token
-3. Choose your preferred language (English, Chinese, or System Default)
+2. Add one or more accounts with a custom name and auth token
+3. Enable/disable accounts as needed
+4. Choose your preferred language (English, Chinese, or System Default)
 
-The app connects to `https://open.bigmodel.cn/api/monitor/usage/*` endpoints using your auth token.
+The app connects to `https://open.bigmodel.cn/api/monitor/usage/*` endpoints using each enabled account token.
 
 ## How It Works
 
 - The app displays as a menu bar item showing the current token usage percentage
-- Clicking the menu bar item opens a popover with detailed usage information
+- Clicking the menu bar item opens a popover with combined totals and per-account details
 - Data is fetched from the ZhiPu monitoring API on launch and every 5 minutes thereafter
 - The refresh button allows manual data refresh at any time
 

--- a/ZaiUsageMenuBar/Package.swift
+++ b/ZaiUsageMenuBar/Package.swift
@@ -13,6 +13,11 @@ let package = Package(
             resources: [
                 .process("Assets.xcassets")
             ]
+        ),
+        .testTarget(
+            name: "ZaiUsageMenuBarTests",
+            dependencies: ["ZaiUsageMenuBar"],
+            path: "Tests/ZaiUsageMenuBarTests"
         )
     ]
 )

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/AccountConfigStore.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/AccountConfigStore.swift
@@ -1,0 +1,230 @@
+import Foundation
+import Security
+
+protocol AuthTokenStore {
+    func authToken(for accountID: String) -> String?
+    func setAuthToken(_ token: String, for accountID: String) throws
+    func removeAuthToken(for accountID: String) throws
+}
+
+enum AccountConfigStore {
+    static let accountsKey = "accountsV1"
+    static let legacyTokenKey = "anthropicAuthToken"
+    private static let tokenStore: AuthTokenStore = KeychainAuthTokenStore()
+    private static let tokenCacheLock = NSLock()
+    private static var tokenCache: [String: TokenCacheEntry] = [:]
+    
+    static func loadAccounts(
+        userDefaults: UserDefaults = .standard,
+        tokenStore: AuthTokenStore = tokenStore
+    ) -> [AccountConfig] {
+        if let data = userDefaults.data(forKey: accountsKey) {
+            if let storedAccounts = try? JSONDecoder().decode([StoredAccountConfig].self, from: data) {
+                return storedAccounts.map {
+                    AccountConfig(
+                        id: $0.id,
+                        name: $0.name,
+                        authToken: cachedAuthToken(for: $0.id, tokenStore: tokenStore) ?? "",
+                        isEnabled: $0.isEnabled
+                    )
+                }
+            }
+            
+            if let legacyAccounts = try? JSONDecoder().decode([AccountConfig].self, from: data) {
+                try? saveAccounts(legacyAccounts, userDefaults: userDefaults, tokenStore: tokenStore)
+                return legacyAccounts
+            }
+        }
+        
+        return migrateLegacyTokenIfNeeded(userDefaults: userDefaults, tokenStore: tokenStore)
+    }
+    
+    static func saveAccounts(
+        _ accounts: [AccountConfig],
+        userDefaults: UserDefaults = .standard,
+        tokenStore: AuthTokenStore = tokenStore
+    ) throws {
+        let existingIDs = accountIDs(in: userDefaults)
+        let storedAccounts = accounts.map { StoredAccountConfig(id: $0.id, name: $0.name, isEnabled: $0.isEnabled) }
+        let data = try JSONEncoder().encode(storedAccounts)
+        userDefaults.set(data, forKey: accountsKey)
+        userDefaults.removeObject(forKey: legacyTokenKey)
+        
+        for account in accounts {
+            let trimmedToken = account.authToken.trimmed
+            if trimmedToken.isEmpty {
+                try tokenStore.removeAuthToken(for: account.id)
+                cacheMissingToken(for: account.id)
+            } else {
+                try tokenStore.setAuthToken(trimmedToken, for: account.id)
+                cacheToken(trimmedToken, for: account.id)
+            }
+        }
+        
+        let removedIDs = existingIDs.subtracting(accounts.map(\.id))
+        for accountID in removedIDs {
+            try tokenStore.removeAuthToken(for: accountID)
+            removeCachedToken(for: accountID)
+        }
+    }
+    
+    private static func migrateLegacyTokenIfNeeded(
+        userDefaults: UserDefaults,
+        tokenStore: AuthTokenStore
+    ) -> [AccountConfig] {
+        let legacyToken = userDefaults.string(forKey: legacyTokenKey)?.trimmed ?? ""
+        guard !legacyToken.isEmpty else { return [] }
+        
+        let account = AccountConfig(
+            id: UUID().uuidString,
+            name: L10n.localized("default_account_name"),
+            authToken: legacyToken,
+            isEnabled: true
+        )
+        
+        try? saveAccounts([account], userDefaults: userDefaults, tokenStore: tokenStore)
+        return [account]
+    }
+    
+    private static func accountIDs(in userDefaults: UserDefaults) -> Set<String> {
+        guard let data = userDefaults.data(forKey: accountsKey),
+              let storedAccounts = try? JSONDecoder().decode([StoredAccountConfig].self, from: data)
+        else {
+            return []
+        }
+        
+        return Set(storedAccounts.map(\.id))
+    }
+
+    static func clearInMemoryTokenCache() {
+        tokenCacheLock.lock()
+        defer { tokenCacheLock.unlock() }
+        tokenCache.removeAll()
+    }
+
+    private static func cachedAuthToken(for accountID: String, tokenStore: AuthTokenStore) -> String? {
+        tokenCacheLock.lock()
+        if let cached = tokenCache[accountID] {
+            tokenCacheLock.unlock()
+            return cached.token
+        }
+        tokenCacheLock.unlock()
+
+        let loadedToken = tokenStore.authToken(for: accountID)
+        tokenCacheLock.lock()
+        tokenCache[accountID] = loadedToken.map(TokenCacheEntry.present) ?? .missing
+        tokenCacheLock.unlock()
+        return loadedToken
+    }
+
+    private static func cacheToken(_ token: String, for accountID: String) {
+        tokenCacheLock.lock()
+        defer { tokenCacheLock.unlock() }
+        tokenCache[accountID] = .present(token)
+    }
+
+    private static func cacheMissingToken(for accountID: String) {
+        tokenCacheLock.lock()
+        defer { tokenCacheLock.unlock() }
+        tokenCache[accountID] = .missing
+    }
+
+    private static func removeCachedToken(for accountID: String) {
+        tokenCacheLock.lock()
+        defer { tokenCacheLock.unlock() }
+        tokenCache.removeValue(forKey: accountID)
+    }
+}
+
+private struct StoredAccountConfig: Codable {
+    let id: String
+    let name: String
+    let isEnabled: Bool
+}
+
+private enum TokenCacheEntry {
+    case present(String)
+    case missing
+
+    var token: String? {
+        switch self {
+        case .present(let token):
+            return token
+        case .missing:
+            return nil
+        }
+    }
+}
+
+private struct KeychainAuthTokenStore: AuthTokenStore {
+    private let service = "com.benjamin.zai-usage-menu-bar.auth-token"
+    
+    func authToken(for accountID: String) -> String? {
+        var query = baseQuery(for: accountID)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess,
+              let data = item as? Data,
+              let token = String(data: data, encoding: .utf8)
+        else {
+            return nil
+        }
+        
+        return token
+    }
+    
+    func setAuthToken(_ token: String, for accountID: String) throws {
+        let data = Data(token.utf8)
+        let query = baseQuery(for: accountID)
+        let attributes = [kSecValueData as String: data]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        
+        if updateStatus == errSecSuccess {
+            return
+        }
+        
+        if updateStatus == errSecItemNotFound {
+            var item = query
+            item[kSecValueData as String] = data
+            let addStatus = SecItemAdd(item as CFDictionary, nil)
+            guard addStatus == errSecSuccess else {
+                throw AccountConfigStoreError.keychainError(status: addStatus)
+            }
+            return
+        }
+        
+        throw AccountConfigStoreError.keychainError(status: updateStatus)
+    }
+    
+    func removeAuthToken(for accountID: String) throws {
+        let status = SecItemDelete(baseQuery(for: accountID) as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw AccountConfigStoreError.keychainError(status: status)
+        }
+    }
+    
+    private func baseQuery(for accountID: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: accountID,
+        ]
+    }
+}
+
+enum AccountConfigStoreError: LocalizedError {
+    case keychainError(status: OSStatus)
+
+    var errorDescription: String? {
+        switch self {
+        case .keychainError(let status):
+            if let message = SecCopyErrorMessageString(status, nil) as String? {
+                return message
+            }
+            return "Keychain error (\(status))."
+        }
+    }
+}

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/AppDelegate.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/AppDelegate.swift
@@ -19,7 +19,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         
         let contentView = MenuBarContentView()
-        popover.contentSize = NSSize(width: 300, height: 260)
+        popover.contentSize = NSSize(width: 300, height: 360)
         popover.behavior = .transient
         popover.contentViewController = NSHostingController(rootView: contentView)
         

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/Localization.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/Localization.swift
@@ -4,85 +4,155 @@ enum L10n {
     static var preferredLanguage: String {
         UserDefaults.standard.string(forKey: "preferredLanguage") ?? "system"
     }
-    
+
+    private static let translations: [String: [String: String]] = [
+        "app_title": [
+            "en": "Zai Usage",
+            "zh": "智谱coding plan 用量查询",
+        ],
+        "settings": [
+            "en": "Settings",
+            "zh": "设置",
+        ],
+        "quit": [
+            "en": "Quit",
+            "zh": "退出",
+        ],
+        "retry": [
+            "en": "Retry",
+            "zh": "重试",
+        ],
+        "refresh": [
+            "en": "Refresh",
+            "zh": "刷新",
+        ],
+        "quota": [
+            "en": "Quota",
+            "zh": "配额",
+        ],
+        "token_label": [
+            "en": "Token (5h)",
+            "zh": "Token (5小时)",
+        ],
+        "mcp_label": [
+            "en": "MCP (1m)",
+            "zh": "MCP (1个月)",
+        ],
+        "resets_prefix": [
+            "en": "resets",
+            "zh": "重置",
+        ],
+        "model_usage": [
+            "en": "Model Usage",
+            "zh": "模型用量",
+        ],
+        "tools": [
+            "en": "Tools",
+            "zh": "工具调用",
+        ],
+        "combined": [
+            "en": "Combined",
+            "zh": "汇总",
+        ],
+        "accounts": [
+            "en": "Accounts",
+            "zh": "账号",
+        ],
+        "add_account": [
+            "en": "Add Account",
+            "zh": "添加账号",
+        ],
+        "enabled": [
+            "en": "Enabled",
+            "zh": "启用",
+        ],
+        "delete": [
+            "en": "Delete",
+            "zh": "删除",
+        ],
+        "cancel": [
+            "en": "Cancel",
+            "zh": "取消",
+        ],
+        "delete_account_title": [
+            "en": "Delete Account?",
+            "zh": "删除账号？",
+        ],
+        "delete_account_message": [
+            "en": "Remove %1$@ from this app? Its saved token will also be removed.",
+            "zh": "要从应用中移除 %1$@ 吗？已保存的令牌也会被删除。",
+        ],
+        "default_account_name": [
+            "en": "Default Account",
+            "zh": "默认账号",
+        ],
+        "unnamed_account": [
+            "en": "Unnamed Account",
+            "zh": "未命名账号",
+        ],
+        "no_accounts_added": [
+            "en": "Add at least one account.",
+            "zh": "请至少添加一个账号。",
+        ],
+        "account_name_placeholder": [
+            "en": "Account name",
+            "zh": "账号名称",
+        ],
+        "account_name_required": [
+            "en": "Enabled accounts need a name.",
+            "zh": "启用的账号必须填写名称。",
+        ],
+        "auth_token_required": [
+            "en": "Enabled accounts need an auth token.",
+            "zh": "启用的账号必须填写认证令牌。",
+        ],
+        "no_accounts_configured": [
+            "en": "No enabled account configured. Open settings to add one.",
+            "zh": "未配置启用账号，请在设置中添加。",
+        ],
+        "all_accounts_failed": [
+            "en": "All account requests failed. Check account tokens.",
+            "zh": "所有账号请求失败，请检查账号令牌。",
+        ],
+        "calls_suffix": [
+            "en": "calls",
+            "zh": "次调用",
+        ],
+        "api_config": [
+            "en": "API Configuration",
+            "zh": "API 配置",
+        ],
+        "base_url": [
+            "en": "Base URL",
+            "zh": "基础 URL",
+        ],
+        "auth_token": [
+            "en": "Auth Token",
+            "zh": "认证令牌",
+        ],
+        "auth_token_placeholder": [
+            "en": "Your authentication token",
+            "zh": "你的认证令牌",
+        ],
+        "done": [
+            "en": "Done",
+            "zh": "完成",
+        ],
+        "language": [
+            "en": "Language",
+            "zh": "语言",
+        ],
+        "system_default": [
+            "en": "System Default",
+            "zh": "跟随系统",
+        ],
+    ]
+
     static func localized(_ key: String) -> String {
-        let lang = preferredLanguage == "system" ? (Locale.current.language.languageCode?.identifier ?? "en") : preferredLanguage
-        
-        let translations: [String: [String: String]] = [
-            "app_title": [
-                "en": "Zai Usage",
-                "zh": "智谱coding plan 用量查询"
-            ],
-            "settings": [
-                "en": "Settings",
-                "zh": "设置"
-            ],
-            "quit": [
-                "en": "Quit",
-                "zh": "退出"
-            ],
-            "retry": [
-                "en": "Retry",
-                "zh": "重试"
-            ],
-            "quota": [
-                "en": "Quota",
-                "zh": "配额"
-            ],
-            "token_label": [
-                "en": "Token (5h)",
-                "zh": "Token (5小时)"
-            ],
-            "mcp_label": [
-                "en": "MCP (1m)",
-                "zh": "MCP (1分钟)"
-            ],
-            "resets_prefix": [
-                "en": "resets",
-                "zh": "重置"
-            ],
-            "model_usage": [
-                "en": "Model Usage",
-                "zh": "模型用量"
-            ],
-            "tools": [
-                "en": "Tools",
-                "zh": "工具调用"
-            ],
-            "calls_suffix": [
-                "en": "calls",
-                "zh": "次调用"
-            ],
-            "api_config": [
-                "en": "API Configuration",
-                "zh": "API 配置"
-            ],
-            "base_url": [
-                "en": "Base URL",
-                "zh": "基础 URL"
-            ],
-            "auth_token": [
-                "en": "Auth Token",
-                "zh": "认证令牌"
-            ],
-            "auth_token_placeholder": [
-                "en": "Your authentication token",
-                "zh": "你的认证令牌"
-            ],
-            "done": [
-                "en": "Done",
-                "zh": "完成"
-            ],
-            "language": [
-                "en": "Language",
-                "zh": "语言"
-            ],
-            "system_default": [
-                "en": "System Default",
-                "zh": "跟随系统"
-            ]
-        ]
-        
+        let lang =
+            preferredLanguage == "system"
+            ? (Locale.current.language.languageCode?.identifier ?? "en") : preferredLanguage
+
         let langKey = lang.hasPrefix("zh") ? "zh" : "en"
         return translations[key]?[langKey] ?? translations[key]?["en"] ?? key
     }

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
@@ -6,7 +6,7 @@ struct MenuBarContentView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            HeaderView(lastUpdated: viewModel.lastUpdated, isLoading: viewModel.isLoading, showSettings: $showSettings, onRefresh: viewModel.refresh)
+            HeaderView(lastUpdated: viewModel.dashboard?.lastUpdated, isLoading: viewModel.isLoading, showSettings: $showSettings, onRefresh: viewModel.refresh)
             
             ScrollView {
                 VStack(spacing: 8) {
@@ -14,16 +14,9 @@ struct MenuBarContentView: View {
                         ErrorView(message: error, retryAction: viewModel.refresh)
                     }
                     
-                    if let quotaLimits = viewModel.quotaLimits {
-                        QuotaLimitsView(quotaData: quotaLimits)
-                    }
-                    
-                    if let modelUsage = viewModel.modelUsage {
-                        ModelUsageView(modelData: modelUsage)
-                    }
-                    
-                    if let toolUsage = viewModel.toolUsage {
-                        ToolUsageView(toolData: toolUsage)
+                    if let dashboard = viewModel.dashboard {
+                        CombinedUsageSectionView(combinedData: dashboard.combined)
+                        AccountsUsageSectionView(results: dashboard.accounts)
                     }
                     
                     if viewModel.isLoading {
@@ -130,6 +123,111 @@ struct ErrorView: View {
     }
 }
 
+struct CombinedUsageSectionView: View {
+    let combinedData: CombinedUsageData
+    
+    private var hasContent: Bool {
+        combinedData.quotaLimits != nil || combinedData.modelUsage != nil || combinedData.toolUsage != nil
+    }
+    
+    var body: some View {
+        if hasContent {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(L10n.localized("combined"))
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.secondary)
+                
+                if let quotaLimits = combinedData.quotaLimits {
+                    QuotaLimitsView(quotaData: quotaLimits)
+                }
+                
+                if let modelUsage = combinedData.modelUsage {
+                    ModelUsageView(modelData: modelUsage)
+                }
+                
+                if let toolUsage = combinedData.toolUsage {
+                    ToolUsageView(toolData: toolUsage)
+                }
+            }
+        }
+    }
+}
+
+struct AccountsUsageSectionView: View {
+    let results: [AccountUsageResult]
+    
+    var body: some View {
+        if !results.isEmpty {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(L10n.localized("accounts"))
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.secondary)
+                
+                ForEach(results) { result in
+                    AccountUsageCardView(result: result)
+                }
+            }
+        }
+    }
+}
+
+struct AccountUsageCardView: View {
+    let result: AccountUsageResult
+
+    private var tokenPercentage: Double? {
+        UsageAggregation.tokenPercentage(from: result.usage?.quotaLimits)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(result.account.displayName)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                Spacer()
+                if let tokenPercentage = tokenPercentage {
+                    Text(String(format: "%.0f%%", tokenPercentage))
+                        .font(.caption2)
+                        .fontWeight(.semibold)
+                        .foregroundColor(progressColor(for: tokenPercentage))
+                }
+            }
+            
+            if let usage = result.usage {
+                HStack(spacing: 12) {
+                    if let tokens = usage.modelUsage.totalUsage?.totalTokensUsage {
+                        Label(formatTokenCount(tokens), systemImage: "number")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                    
+                    if let calls = usage.modelUsage.totalUsage?.totalModelCallCount {
+                        Label("\(calls)", systemImage: "bubble.left")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                    
+                    if let toolCalls = usage.toolUsage.totalUsage?.totalSearchMcpCount {
+                        Label("\(toolCalls)", systemImage: "wrench.and.screwdriver")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            } else if let error = result.error {
+                Text(error)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .lineLimit(3)
+            }
+        }
+        .padding(8)
+        .background(Color(NSColor.controlBackgroundColor))
+        .cornerRadius(6)
+    }
+}
+
 struct QuotaLimitsView: View {
     let quotaData: QuotaLimitData
     
@@ -181,40 +279,34 @@ struct QuotaLimitRow: View {
         guard let nextResetTime = limit.nextResetTime else { return nil }
         return Date(timeIntervalSince1970: nextResetTime / 1000)
     }
-    
-    var progressColor: Color {
-        guard let percentage = limit.percentage else { return .green }
-        if percentage >= 90 { return .red }
-        else if percentage >= 70 { return .orange }
-        else { return .green }
-    }
-    
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 3) {
+        let color = progressColor(for: limit.percentage)
+        return VStack(alignment: .leading, spacing: 3) {
             HStack {
                 Text(label)
                     .font(.caption2)
                     .foregroundColor(.secondary)
-                
+
                 Spacer()
-                
+
                 if let current = limit.currentValue, let usage = limit.usage {
                     Text(String(format: "%.0f/%.0f", current, usage))
                         .font(.caption2)
                         .foregroundColor(.secondary)
                 }
-                
+
                 if let percentage = limit.percentage {
                     Text(String(format: "%.0f%%", percentage))
                         .font(.caption2)
                         .fontWeight(.semibold)
-                        .foregroundColor(progressColor)
+                        .foregroundColor(color)
                 }
             }
-            
+
             if let percentage = limit.percentage {
                 ProgressView(value: min(percentage, 100), total: 100)
-                    .progressViewStyle(LinearProgressViewStyle(tint: progressColor))
+                    .progressViewStyle(LinearProgressViewStyle(tint: color))
                     .frame(height: 3)
             }
             
@@ -243,7 +335,7 @@ struct ModelUsageView: View {
                     .fontWeight(.semibold)
                 Spacer()
                 if let totalUsage = modelData.totalUsage, let tokens = totalUsage.totalTokensUsage {
-                    Text(formatTokens(tokens))
+                    Text(formatTokenCount(tokens))
                         .font(.caption2)
                         .foregroundColor(.secondary)
                 }
@@ -260,12 +352,6 @@ struct ModelUsageView: View {
         .padding(8)
         .background(Color(NSColor.controlBackgroundColor))
         .cornerRadius(6)
-    }
-    
-    func formatTokens(_ count: Int) -> String {
-        if count >= 1_000_000 { return String(format: "%.1fM", Double(count) / 1_000_000) }
-        else if count >= 1_000 { return String(format: "%.1fK", Double(count) / 1_000) }
-        return "\(count)"
     }
 }
 
@@ -303,4 +389,17 @@ struct ToolUsageView: View {
         .background(Color(NSColor.controlBackgroundColor))
         .cornerRadius(6)
     }
+}
+
+func formatTokenCount(_ count: Int) -> String {
+    if count >= 1_000_000 { return String(format: "%.1fM", Double(count) / 1_000_000) }
+    if count >= 1_000 { return String(format: "%.1fK", Double(count) / 1_000) }
+    return "\(count)"
+}
+
+func progressColor(for percentage: Double?) -> Color {
+    guard let percentage else { return .green }
+    if percentage >= 90 { return .red }
+    if percentage >= 70 { return .orange }
+    return .green
 }

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/SettingsView.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/SettingsView.swift
@@ -2,11 +2,13 @@ import SwiftUI
 
 struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
-    @AppStorage("anthropicAuthToken") private var authToken: String = ""
     @AppStorage("preferredLanguage") private var preferredLanguage: String = "system"
+    @State private var accounts: [AccountConfig] = []
+    @State private var errorMessage: String?
+    @State private var pendingDeleteAccount: AccountConfig?
     
     var body: some View {
-        VStack(spacing: 20) {
+        VStack(spacing: 12) {
             Form {
                 Section(L10n.localized("language")) {
                     Picker(L10n.localized("language"), selection: $preferredLanguage) {
@@ -28,27 +30,139 @@ struct SettingsView: View {
                     }
                     
                     VStack(alignment: .leading, spacing: 8) {
-                        Text(L10n.localized("auth_token"))
-                            .font(.caption)
-                            .fontWeight(.medium)
+                        HStack {
+                            Text(L10n.localized("accounts"))
+                                .font(.caption)
+                                .fontWeight(.medium)
+                            Spacer()
+                            Button(L10n.localized("add_account")) {
+                                accounts.append(AccountConfig.newDefault())
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                        }
                         
-                        SecureField(L10n.localized("auth_token_placeholder"), text: $authToken)
-                            .textFieldStyle(.roundedBorder)
+                        if accounts.isEmpty {
+                            Text(L10n.localized("no_accounts_added"))
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .padding(.vertical, 4)
+                        } else {
+                            ForEach($accounts) { $account in
+                                AccountEditorRow(account: $account) {
+                                    pendingDeleteAccount = account
+                                }
+                            }
+                        }
                     }
                 }
+            }
+            
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption2)
+                    .foregroundColor(.red)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
             
             HStack {
                 Spacer()
                 
                 Button(L10n.localized("done")) {
-                    dismiss()
+                    saveAndDismiss()
                 }
                 .keyboardShortcut(.return)
                 .buttonStyle(.borderedProminent)
             }
         }
         .padding()
-        .frame(width: 400, height: 200)
+        .frame(width: 420, height: 420)
+        .onAppear {
+            accounts = AccountConfigStore.loadAccounts()
+            if accounts.isEmpty {
+                accounts = [AccountConfig.newDefault()]
+            }
+        }
+        .alert(item: $pendingDeleteAccount) { account in
+            Alert(
+                title: Text(L10n.localized("delete_account_title")),
+                message: Text(
+                    String(
+                        format: L10n.localized("delete_account_message"),
+                        account.displayName
+                    )
+                ),
+                primaryButton: .destructive(Text(L10n.localized("delete"))) {
+                    removeAccount(id: account.id)
+                },
+                secondaryButton: .cancel(Text(L10n.localized("cancel")))
+            )
+        }
+    }
+    
+    private func removeAccount(id: String) {
+        accounts.removeAll { $0.id == id }
+    }
+    
+    private func saveAndDismiss() {
+        errorMessage = nil
+        
+        guard let validationError = validateAccounts(accounts) else {
+            do {
+                try AccountConfigStore.saveAccounts(accounts)
+                NotificationCenter.default.post(name: .refreshUsage, object: nil)
+                dismiss()
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            return
+        }
+        
+        errorMessage = validationError
+    }
+    
+    private func validateAccounts(_ accounts: [AccountConfig]) -> String? {
+        if accounts.isEmpty {
+            return L10n.localized("no_accounts_added")
+        }
+        
+        for account in accounts where account.isEnabled {
+            if account.name.trimmed.isEmpty {
+                return L10n.localized("account_name_required")
+            }
+            if account.authToken.trimmed.isEmpty {
+                return L10n.localized("auth_token_required")
+            }
+        }
+        
+        return nil
+    }
+}
+
+private struct AccountEditorRow: View {
+    @Binding var account: AccountConfig
+    let onDelete: () -> Void
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            TextField(L10n.localized("account_name_placeholder"), text: $account.name)
+                .textFieldStyle(.roundedBorder)
+            
+            SecureField(L10n.localized("auth_token_placeholder"), text: $account.authToken)
+                .textFieldStyle(.roundedBorder)
+            
+            HStack {
+                Toggle(L10n.localized("enabled"), isOn: $account.isEnabled)
+                    .toggleStyle(.switch)
+                Spacer()
+                Button(role: .destructive, action: onDelete) {
+                    Label(L10n.localized("delete"), systemImage: "trash")
+                }
+                .controlSize(.small)
+            }
+        }
+        .padding(8)
+        .background(Color(NSColor.controlBackgroundColor))
+        .cornerRadius(6)
     }
 }

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/StringExtensions.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/StringExtensions.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension String {
+    var trimmed: String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageAPIClient.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageAPIClient.swift
@@ -9,8 +9,9 @@ class UsageAPIClient {
     
     private init() {}
     
-    func fetchUsage() async throws -> UsageData {
-        guard let authToken = UserDefaults.standard.string(forKey: "anthropicAuthToken"), !authToken.isEmpty else {
+    func fetchUsage(for account: AccountConfig) async throws -> UsageData {
+        let authToken = account.authToken.trimmed
+        guard !authToken.isEmpty else {
             throw UsageError.missingAuthToken
         }
         
@@ -63,6 +64,29 @@ class UsageAPIClient {
             quotaLimits: quotaLimitResponse.data,
             lastUpdated: Date()
         )
+    }
+    
+    func fetchAllUsage(accounts: [AccountConfig]) async -> [AccountUsageResult] {
+        guard !accounts.isEmpty else { return [] }
+        
+        return await withTaskGroup(of: (Int, AccountUsageResult).self) { group in
+            for (index, account) in accounts.enumerated() {
+                group.addTask {
+                    do {
+                        let usage = try await self.fetchUsage(for: account)
+                        return (index, AccountUsageResult(account: account, usage: usage, error: nil))
+                    } catch {
+                        return (index, AccountUsageResult(account: account, usage: nil, error: error.localizedDescription))
+                    }
+                }
+            }
+            
+            var orderedResults = Array<AccountUsageResult?>(repeating: nil, count: accounts.count)
+            for await (index, result) in group {
+                orderedResults[index] = result
+            }
+            return orderedResults.compactMap { $0 }
+        }
     }
     
     private func fetchJSON(url: String, startTime: String?, endTime: String?, authToken: String) async throws -> Data {

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageAggregation.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageAggregation.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+enum UsageAggregation {
+    static func combine(_ usages: [UsageData]) -> CombinedUsageData {
+        guard !usages.isEmpty else {
+            return CombinedUsageData(modelUsage: nil, toolUsage: nil, quotaLimits: nil)
+        }
+        
+        return CombinedUsageData(
+            modelUsage: combineModelUsage(usages),
+            toolUsage: combineToolUsage(usages),
+            quotaLimits: combineQuotaLimits(usages)
+        )
+    }
+    
+    static func tokenPercentage(from quotaLimits: QuotaLimitData?) -> Double? {
+        let tokenLimit = quotaLimits?.limits?.first { $0.type == "TOKENS_LIMIT" }
+        return percentage(for: tokenLimit)
+    }
+    
+    private static func combineModelUsage(_ usages: [UsageData]) -> ModelUsageData {
+        let totalTokens = usages.compactMap { $0.modelUsage.totalUsage?.totalTokensUsage }.reduce(0, +)
+        let totalCalls = usages.compactMap { $0.modelUsage.totalUsage?.totalModelCallCount }.reduce(0, +)
+        
+        return ModelUsageData(
+            xTime: nil,
+            modelCallCount: nil,
+            tokensUsage: nil,
+            totalUsage: ModelUsageTotal(
+                totalModelCallCount: totalCalls,
+                totalTokensUsage: totalTokens
+            )
+        )
+    }
+    
+    private static func combineToolUsage(_ usages: [UsageData]) -> ToolUsageData {
+        var totalNetworkSearch = 0
+        var totalWebRead = 0
+        var totalZRead = 0
+        var totalSearchMcp = 0
+        var detailsByModel: [String: Int] = [:]
+        
+        for usage in usages {
+            if let totals = usage.toolUsage.totalUsage {
+                totalNetworkSearch += totals.totalNetworkSearchCount ?? 0
+                totalWebRead += totals.totalWebReadMcpCount ?? 0
+                totalZRead += totals.totalZreadMcpCount ?? 0
+                totalSearchMcp += totals.totalSearchMcpCount ?? 0
+                
+                for detail in totals.toolDetails ?? [] {
+                    guard let modelName = detail.modelName, !modelName.isEmpty else { continue }
+                    detailsByModel[modelName, default: 0] += detail.totalUsageCount ?? 0
+                }
+            }
+        }
+        
+        let mergedDetails = detailsByModel
+            .keys
+            .sorted()
+            .map { ToolDetail(modelName: $0, totalUsageCount: detailsByModel[$0]) }
+        
+        return ToolUsageData(
+            xTime: nil,
+            totalUsage: ToolUsageTotal(
+                totalNetworkSearchCount: totalNetworkSearch,
+                totalWebReadMcpCount: totalWebRead,
+                totalZreadMcpCount: totalZRead,
+                totalSearchMcpCount: totalSearchMcp,
+                toolDetails: mergedDetails
+            )
+        )
+    }
+    
+    private static func combineQuotaLimits(_ usages: [UsageData]) -> QuotaLimitData {
+        let allLimits = usages.flatMap { $0.quotaLimits.limits ?? [] }
+        let grouped = Dictionary(grouping: allLimits, by: { $0.type ?? "" })
+            .filter { !$0.key.isEmpty }
+
+        let sortedTypes = grouped.keys.sorted { lhs, rhs in
+            if lhs == "TOKENS_LIMIT" { return true }
+            if rhs == "TOKENS_LIMIT" { return false }
+            if lhs == "TIME_LIMIT" { return true }
+            if rhs == "TIME_LIMIT" { return false }
+            return lhs < rhs
+        }
+
+        let combinedLimits = sortedTypes.compactMap { type -> QuotaLimit? in
+            guard let limits = grouped[type], !limits.isEmpty else { return nil }
+            let summedUsage = limits.compactMap(\.usage).reduce(0, +)
+            let summedCurrent = limits.compactMap(\.currentValue).reduce(0, +)
+            let hasUsage = limits.contains { $0.usage != nil }
+            let hasCurrent = limits.contains { $0.currentValue != nil }
+            let usageValue = hasUsage ? summedUsage : nil
+            let currentValue = hasCurrent ? summedCurrent : nil
+            let explicitPercentages = limits.compactMap(\.percentage)
+            let percentage: Double?
+            if let usageValue, let currentValue, usageValue > 0 {
+                percentage = currentValue / usageValue * 100
+            } else if explicitPercentages.isEmpty {
+                percentage = nil
+            } else {
+                percentage = explicitPercentages.reduce(0, +) / Double(explicitPercentages.count)
+            }
+            let earliestReset = limits.compactMap(\.nextResetTime).min()
+            let remaining: Double?
+            if let usageValue, let currentValue {
+                remaining = max(usageValue - currentValue, 0)
+            } else {
+                remaining = nil
+            }
+            
+            return QuotaLimit(
+                type: type,
+                unit: commonValue(in: limits.compactMap(\.unit)),
+                number: commonValue(in: limits.compactMap(\.number)),
+                usage: usageValue,
+                currentValue: currentValue,
+                remaining: remaining,
+                percentage: percentage,
+                nextResetTime: earliestReset,
+                usageDetails: nil
+            )
+        }
+        
+        let level = commonValue(in: usages.compactMap { $0.quotaLimits.level })
+        return QuotaLimitData(limits: combinedLimits, level: level)
+    }
+    
+    private static func commonValue<T: Hashable>(in values: [T]) -> T? {
+        let uniqueValues = Set(values)
+        guard uniqueValues.count == 1 else { return nil }
+        return uniqueValues.first
+    }
+
+    private static func percentage(for limit: QuotaLimit?) -> Double? {
+        guard let limit else { return nil }
+        if let percentage = limit.percentage {
+            return percentage
+        }
+
+        if let usage = limit.usage, usage > 0 {
+            if let currentValue = limit.currentValue {
+                return currentValue / usage * 100
+            }
+            if let remaining = limit.remaining {
+                return max(min((usage - remaining) / usage * 100, 100), 0)
+            }
+        }
+
+        return nil
+    }
+}

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageModels.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageModels.swift
@@ -70,3 +70,42 @@ struct UsageDetail: Codable {
     let modelCode: String?
     let usage: Double?
 }
+
+struct AccountConfig: Codable, Identifiable, Hashable {
+    let id: String
+    var name: String
+    var authToken: String
+    var isEnabled: Bool
+
+    var displayName: String {
+        name.trimmed.isEmpty ? L10n.localized("unnamed_account") : name
+    }
+    
+    static func newDefault() -> AccountConfig {
+        AccountConfig(
+            id: UUID().uuidString,
+            name: L10n.localized("default_account_name"),
+            authToken: "",
+            isEnabled: true
+        )
+    }
+}
+
+struct AccountUsageResult: Identifiable {
+    var id: String { account.id }
+    let account: AccountConfig
+    let usage: UsageData?
+    let error: String?
+}
+
+struct CombinedUsageData {
+    let modelUsage: ModelUsageData?
+    let toolUsage: ToolUsageData?
+    let quotaLimits: QuotaLimitData?
+}
+
+struct UsageDashboardData {
+    let combined: CombinedUsageData
+    let accounts: [AccountUsageResult]
+    let lastUpdated: Date
+}

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageViewModel.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageViewModel.swift
@@ -3,13 +3,10 @@ import Foundation
 
 @MainActor
 class UsageViewModel: ObservableObject {
-    @Published var modelUsage: ModelUsageData?
-    @Published var toolUsage: ToolUsageData?
-    @Published var quotaLimits: QuotaLimitData?
+    @Published var dashboard: UsageDashboardData?
     @Published var isLoading = false
     @Published var error: String?
-    @Published var lastUpdated: Date?
-    
+
     func refresh() {
         guard !isLoading else { return }
         
@@ -17,20 +14,34 @@ class UsageViewModel: ObservableObject {
         error = nil
         
         Task {
-            do {
-                let usageData = try await UsageAPIClient.shared.fetchUsage()
-                self.modelUsage = usageData.modelUsage
-                self.toolUsage = usageData.toolUsage
-                self.quotaLimits = usageData.quotaLimits
-                self.lastUpdated = usageData.lastUpdated
-                self.error = nil
-                
-                let tokenLimit = usageData.quotaLimits.limits?.first { $0.type == "TOKENS_LIMIT" }
-                AppDelegate.shared?.updateStatusItem(percentage: tokenLimit?.percentage)
-            } catch {
-                self.error = error.localizedDescription
+            let accounts = AccountConfigStore.loadAccounts()
+            let enabledAccounts = accounts.filter { $0.isEnabled && !$0.authToken.trimmed.isEmpty }
+            
+            guard !enabledAccounts.isEmpty else {
+                self.dashboard = nil
+                self.error = L10n.localized("no_accounts_configured")
                 AppDelegate.shared?.updateStatusItem(percentage: nil)
+                self.isLoading = false
+                return
             }
+            
+            let accountResults = await UsageAPIClient.shared.fetchAllUsage(accounts: enabledAccounts)
+            let successfulUsages = accountResults.compactMap(\.usage)
+            let combined = UsageAggregation.combine(successfulUsages)
+            let now = Date()
+            
+            self.dashboard = UsageDashboardData(combined: combined, accounts: accountResults, lastUpdated: now)
+
+            if successfulUsages.isEmpty {
+                self.error = L10n.localized("all_accounts_failed")
+                AppDelegate.shared?.updateStatusItem(percentage: nil)
+            } else {
+                self.error = nil
+                AppDelegate.shared?.updateStatusItem(
+                    percentage: UsageAggregation.tokenPercentage(from: combined.quotaLimits)
+                )
+            }
+            
             self.isLoading = false
         }
     }

--- a/ZaiUsageMenuBar/Tests/ZaiUsageMenuBarTests/AccountConfigStoreTests.swift
+++ b/ZaiUsageMenuBar/Tests/ZaiUsageMenuBarTests/AccountConfigStoreTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import ZaiUsageMenuBar
+
+final class AccountConfigStoreTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        AccountConfigStore.clearInMemoryTokenCache()
+    }
+
+    func testLoadAccountsMigratesLegacyTokenWhenAccountsMissing() {
+        let defaults = makeDefaults()
+        let tokenStore = InMemoryAuthTokenStore()
+        defaults.set("legacy-token", forKey: "anthropicAuthToken")
+
+        let accounts = AccountConfigStore.loadAccounts(userDefaults: defaults, tokenStore: tokenStore)
+
+        XCTAssertEqual(accounts.count, 1)
+        XCTAssertEqual(accounts.first?.authToken, "legacy-token")
+        XCTAssertTrue(accounts.first?.isEnabled == true)
+        XCTAssertEqual(tokenStore.authToken(for: accounts[0].id), "legacy-token")
+    }
+
+    func testSaveAccountsStoresTokensOutsideUserDefaults() throws {
+        let defaults = makeDefaults()
+        let tokenStore = InMemoryAuthTokenStore()
+        let saved = [AccountConfig(id: "a1", name: "A", authToken: "token-a", isEnabled: true)]
+
+        try AccountConfigStore.saveAccounts(saved, userDefaults: defaults, tokenStore: tokenStore)
+        let rawData = try XCTUnwrap(defaults.data(forKey: AccountConfigStore.accountsKey))
+        let rawString = try XCTUnwrap(String(data: rawData, encoding: .utf8))
+        let accounts = AccountConfigStore.loadAccounts(userDefaults: defaults, tokenStore: tokenStore)
+
+        XCTAssertFalse(rawString.contains("token-a"))
+        XCTAssertEqual(tokenStore.authToken(for: "a1"), "token-a")
+        XCTAssertEqual(accounts, saved)
+    }
+
+    func testLoadAccountsCachesAuthTokensBetweenRefreshes() throws {
+        let defaults = makeDefaults()
+        let tokenStore = CountingAuthTokenStore(tokens: ["a1": "token-a"])
+        let stored = [StoredAccountConfig(id: "a1", name: "A", isEnabled: true)]
+        defaults.set(try JSONEncoder().encode(stored), forKey: AccountConfigStore.accountsKey)
+
+        _ = AccountConfigStore.loadAccounts(userDefaults: defaults, tokenStore: tokenStore)
+        _ = AccountConfigStore.loadAccounts(userDefaults: defaults, tokenStore: tokenStore)
+
+        XCTAssertEqual(tokenStore.readCount, 1)
+    }
+
+    private func makeDefaults(file: StaticString = #filePath, line: UInt = #line) -> UserDefaults {
+        let name = "test.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: name) else {
+            XCTFail("Could not create UserDefaults suite", file: file, line: line)
+            return .standard
+        }
+        defaults.removePersistentDomain(forName: name)
+        return defaults
+    }
+}
+
+private final class InMemoryAuthTokenStore: AuthTokenStore {
+    private var tokens: [String: String] = [:]
+
+    func authToken(for accountID: String) -> String? {
+        tokens[accountID]
+    }
+
+    func setAuthToken(_ token: String, for accountID: String) throws {
+        tokens[accountID] = token
+    }
+
+    func removeAuthToken(for accountID: String) throws {
+        tokens.removeValue(forKey: accountID)
+    }
+}
+
+private final class CountingAuthTokenStore: AuthTokenStore {
+    private var tokens: [String: String]
+    private(set) var readCount = 0
+
+    init(tokens: [String: String]) {
+        self.tokens = tokens
+    }
+
+    func authToken(for accountID: String) -> String? {
+        readCount += 1
+        return tokens[accountID]
+    }
+
+    func setAuthToken(_ token: String, for accountID: String) throws {
+        tokens[accountID] = token
+    }
+
+    func removeAuthToken(for accountID: String) throws {
+        tokens.removeValue(forKey: accountID)
+    }
+}
+
+private struct StoredAccountConfig: Codable {
+    let id: String
+    let name: String
+    let isEnabled: Bool
+}

--- a/ZaiUsageMenuBar/Tests/ZaiUsageMenuBarTests/UsageAggregationTests.swift
+++ b/ZaiUsageMenuBar/Tests/ZaiUsageMenuBarTests/UsageAggregationTests.swift
@@ -1,0 +1,168 @@
+import XCTest
+@testable import ZaiUsageMenuBar
+
+final class UsageAggregationTests: XCTestCase {
+    func testCombineUsageSumsModelTotalsAcrossAccounts() {
+        let usageA = makeUsage(tokens: 100, calls: 2, currentValue: 20, usageLimit: 100)
+        let usageB = makeUsage(tokens: 200, calls: 3, currentValue: 30, usageLimit: 150)
+
+        let combined = UsageAggregation.combine([usageA, usageB])
+
+        XCTAssertEqual(combined.modelUsage?.totalUsage?.totalTokensUsage, 300)
+        XCTAssertEqual(combined.modelUsage?.totalUsage?.totalModelCallCount, 5)
+    }
+
+    func testCombineUsageMergesToolDetailsByModelName() {
+        let usageA = makeUsage(
+            tokens: 100,
+            calls: 2,
+            currentValue: 20,
+            usageLimit: 100,
+            toolDetails: [
+                ToolDetail(modelName: "glm-4.5", totalUsageCount: 3),
+                ToolDetail(modelName: "glm-4-air", totalUsageCount: 1)
+            ]
+        )
+        let usageB = makeUsage(
+            tokens: 200,
+            calls: 5,
+            currentValue: 50,
+            usageLimit: 200,
+            toolDetails: [
+                ToolDetail(modelName: "glm-4.5", totalUsageCount: 4)
+            ]
+        )
+
+        let combined = UsageAggregation.combine([usageA, usageB])
+        let merged = Dictionary(uniqueKeysWithValues: (combined.toolUsage?.totalUsage?.toolDetails ?? []).map { ($0.modelName ?? "", $0.totalUsageCount ?? 0) })
+
+        XCTAssertEqual(merged["glm-4.5"], 7)
+        XCTAssertEqual(merged["glm-4-air"], 1)
+    }
+
+    func testTokenPercentageUsesAggregatedTokenLimit() {
+        let usageA = makeUsage(tokens: 100, calls: 2, currentValue: 20, usageLimit: 100)
+        let usageB = makeUsage(tokens: 200, calls: 3, currentValue: 30, usageLimit: 100)
+
+        let combined = UsageAggregation.combine([usageA, usageB])
+        let percentage = UsageAggregation.tokenPercentage(from: combined.quotaLimits)
+
+        XCTAssertEqual(percentage ?? -1, 25, accuracy: 0.001)
+    }
+
+    func testCombineUsagePreservesPercentageOnlyTokenLimitAcrossAccounts() {
+        let usageA = makeUsage(
+            tokens: 100,
+            calls: 2,
+            currentValue: 78,
+            usageLimit: 100,
+            tokenQuota: makeTokenQuota(percentage: 18, nextResetTime: 1_710_000_000_000),
+            timeQuota: makeTimeQuota(currentValue: 78, usageLimit: 100)
+        )
+        let usageB = makeUsage(
+            tokens: 200,
+            calls: 3,
+            currentValue: 78,
+            usageLimit: 100,
+            tokenQuota: makeTokenQuota(percentage: 18, nextResetTime: 1_710_000_000_000),
+            timeQuota: makeTimeQuota(currentValue: 78, usageLimit: 100)
+        )
+
+        let combined = UsageAggregation.combine([usageA, usageB])
+        let tokenLimit = try? XCTUnwrap(combined.quotaLimits?.limits?.first { $0.type == "TOKENS_LIMIT" })
+
+        XCTAssertEqual(tokenLimit?.percentage ?? -1, 18, accuracy: 0.001)
+        XCTAssertEqual(UsageAggregation.tokenPercentage(from: combined.quotaLimits) ?? -1, 18, accuracy: 0.001)
+    }
+
+    func testCombineUsageHidesMixedQuotaMetadata() {
+        let usageA = makeUsage(tokens: 100, calls: 2, currentValue: 20, usageLimit: 100, unit: 1, number: 1, level: "pro")
+        let usageB = makeUsage(tokens: 200, calls: 3, currentValue: 30, usageLimit: 100, unit: 2, number: 2, level: "free")
+
+        let combined = UsageAggregation.combine([usageA, usageB])
+        let tokenLimit = try? XCTUnwrap(combined.quotaLimits?.limits?.first { $0.type == "TOKENS_LIMIT" })
+
+        XCTAssertNil(tokenLimit?.unit)
+        XCTAssertNil(tokenLimit?.number)
+        XCTAssertNil(combined.quotaLimits?.level)
+    }
+
+    private func makeUsage(
+        tokens: Int,
+        calls: Int,
+        currentValue: Double,
+        usageLimit: Double,
+        toolDetails: [ToolDetail] = [],
+        unit: Int = 1,
+        number: Int = 1,
+        level: String = "pro",
+        tokenQuota: QuotaLimit? = nil,
+        timeQuota: QuotaLimit? = nil
+    ) -> UsageData {
+        let model = ModelUsageData(
+            xTime: nil,
+            modelCallCount: nil,
+            tokensUsage: nil,
+            totalUsage: ModelUsageTotal(totalModelCallCount: calls, totalTokensUsage: tokens)
+        )
+
+        let tool = ToolUsageData(
+            xTime: nil,
+            totalUsage: ToolUsageTotal(
+                totalNetworkSearchCount: 1,
+                totalWebReadMcpCount: 2,
+                totalZreadMcpCount: 3,
+                totalSearchMcpCount: 4,
+                toolDetails: toolDetails
+            )
+        )
+
+        let quota = QuotaLimitData(
+            limits: [
+                tokenQuota ?? QuotaLimit(
+                    type: "TOKENS_LIMIT",
+                    unit: unit,
+                    number: number,
+                    usage: usageLimit,
+                    currentValue: currentValue,
+                    remaining: usageLimit - currentValue,
+                    percentage: currentValue / usageLimit * 100,
+                    nextResetTime: 1_710_000_000_000,
+                    usageDetails: nil
+                ),
+                timeQuota
+            ].compactMap { $0 },
+            level: level
+        )
+
+        return UsageData(modelUsage: model, toolUsage: tool, quotaLimits: quota, lastUpdated: Date())
+    }
+
+    private func makeTokenQuota(percentage: Double, nextResetTime: TimeInterval) -> QuotaLimit {
+        QuotaLimit(
+            type: "TOKENS_LIMIT",
+            unit: 3,
+            number: 5,
+            usage: nil,
+            currentValue: nil,
+            remaining: nil,
+            percentage: percentage,
+            nextResetTime: nextResetTime,
+            usageDetails: nil
+        )
+    }
+
+    private func makeTimeQuota(currentValue: Double, usageLimit: Double) -> QuotaLimit {
+        QuotaLimit(
+            type: "TIME_LIMIT",
+            unit: 5,
+            number: 1,
+            usage: usageLimit,
+            currentValue: currentValue,
+            remaining: usageLimit - currentValue,
+            percentage: currentValue / usageLimit * 100,
+            nextResetTime: 1_710_000_000_000,
+            usageDetails: nil
+        )
+    }
+}

--- a/ZaiUsageMenuBar/build-app.sh
+++ b/ZaiUsageMenuBar/build-app.sh
@@ -8,6 +8,16 @@ CONTENTS="$APP_BUNDLE/Contents"
 MACOS="$CONTENTS/MacOS"
 RESOURCES="$CONTENTS/Resources"
 
+resolve_signing_identity() {
+    if [[ -n "${SIGNING_IDENTITY:-}" ]]; then
+        echo "$SIGNING_IDENTITY"
+        return
+    fi
+
+    # Prefer a real code-signing certificate so Keychain trust can persist across rebuilds.
+    security find-identity -v -p codesigning | awk -F'"' '/"[^"]+"/ { print $2; exit }'
+}
+
 # Build release binary
 swift build -c release
 
@@ -73,6 +83,19 @@ PLIST
 echo "App bundle created at: $APP_BUNDLE"
 echo "Run with: open $APP_BUNDLE"
 
-# Ad-hoc sign the app bundle for Gatekeeper compatibility
-codesign --force --sign - --options runtime "$APP_BUNDLE"
-echo "App bundle signed"
+SIGNING_IDENTITY="$(resolve_signing_identity)"
+
+if [[ -z "$SIGNING_IDENTITY" ]]; then
+    if [[ "${ALLOW_ADHOC_SIGNING:-0}" == "1" ]]; then
+        SIGNING_IDENTITY="-"
+        echo "Warning: no signing certificate found, using ad-hoc signing."
+    else
+        echo "Error: no code-signing identity found."
+        echo "Set SIGNING_IDENTITY to a valid identity name, or set ALLOW_ADHOC_SIGNING=1 to force ad-hoc signing."
+        echo "Tip: run 'security find-identity -v -p codesigning' to list identities."
+        exit 1
+    fi
+fi
+
+codesign --force --deep --sign "$SIGNING_IDENTITY" --options runtime --timestamp=none "$APP_BUNDLE"
+echo "App bundle signed with identity: $SIGNING_IDENTITY"

--- a/docs/superpowers/plans/2026-04-04-chinese-language-support.md
+++ b/docs/superpowers/plans/2026-04-04-chinese-language-support.md
@@ -130,7 +130,7 @@ Create the string catalog file with English base and Chinese (Simplified) transl
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "MCP (1分钟)"
+            "value": "MCP (1个月)"
           }
         }
       }

--- a/docs/superpowers/plans/2026-04-08-multi-account-usage.md
+++ b/docs/superpowers/plans/2026-04-08-multi-account-usage.md
@@ -1,0 +1,271 @@
+# Multi-Account Usage Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement multi-account API support with combined totals and per-account breakdown in the menu bar popover.
+
+**Architecture:** Add an account store (`accountsV1`) with legacy-token migration, fetch enabled accounts concurrently, aggregate successful payloads into combined usage, and render both combined and per-account cards in UI. Keep failures isolated at account level so one failure does not block others.
+
+**Tech Stack:** Swift 5.9, SwiftUI, Foundation, XCTest, Swift Package Manager.
+
+---
+
+### Task 1: Add Test Target and RED Tests for Core Logic
+
+**Files:**
+- Modify: `ZaiUsageMenuBar/Package.swift`
+- Create: `ZaiUsageMenuBar/Tests/ZaiUsageMenuBarTests/AccountConfigStoreTests.swift`
+- Create: `ZaiUsageMenuBar/Tests/ZaiUsageMenuBarTests/UsageAggregationTests.swift`
+
+- [ ] **Step 1: Add test target**
+
+```swift
+// In Package.swift targets:
+.testTarget(
+    name: "ZaiUsageMenuBarTests",
+    dependencies: ["ZaiUsageMenuBar"],
+    path: "Tests/ZaiUsageMenuBarTests"
+)
+```
+
+- [ ] **Step 2: Write failing migration test**
+
+```swift
+func testLoadAccountsMigratesLegacyTokenWhenAccountsMissing() throws {
+    let defaults = makeDefaults()
+    defaults.set("legacy-token", forKey: AccountConfigStore.legacyTokenKey)
+    let accounts = AccountConfigStore.loadAccounts(userDefaults: defaults)
+    XCTAssertEqual(accounts.count, 1)
+    XCTAssertEqual(accounts.first?.authToken, "legacy-token")
+}
+```
+
+- [ ] **Step 3: Write failing aggregation tests**
+
+```swift
+func testCombineUsageSumsTotalsAcrossAccounts() {
+    let combined = UsageAggregation.combine([makeUsage(tokens: 100, calls: 2), makeUsage(tokens: 200, calls: 3)])
+    XCTAssertEqual(combined.modelUsage?.totalUsage?.totalTokensUsage, 300)
+    XCTAssertEqual(combined.modelUsage?.totalUsage?.totalModelCallCount, 5)
+}
+```
+
+- [ ] **Step 4: Run tests and verify RED**
+
+Run: `cd ZaiUsageMenuBar && swift test`  
+Expected: FAIL because `AccountConfigStore`/`UsageAggregation` are not implemented yet.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ZaiUsageMenuBar/Package.swift ZaiUsageMenuBar/Tests/ZaiUsageMenuBarTests/AccountConfigStoreTests.swift ZaiUsageMenuBar/Tests/ZaiUsageMenuBarTests/UsageAggregationTests.swift
+git commit -m "test: add failing tests for account migration and usage aggregation"
+```
+
+### Task 2: Implement Account Store and Aggregator (GREEN)
+
+**Files:**
+- Create: `ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/AccountConfigStore.swift`
+- Create: `ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageAggregation.swift`
+- Modify: `ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageModels.swift`
+- Test: `ZaiUsageMenuBar/Tests/ZaiUsageMenuBarTests/AccountConfigStoreTests.swift`
+- Test: `ZaiUsageMenuBar/Tests/ZaiUsageMenuBarTests/UsageAggregationTests.swift`
+
+- [ ] **Step 1: Add account and dashboard models**
+
+```swift
+struct AccountConfig: Codable, Identifiable, Hashable {
+    let id: String
+    var name: String
+    var authToken: String
+    var isEnabled: Bool
+}
+
+struct AccountUsageResult: Identifiable {
+    var id: String { account.id }
+    let account: AccountConfig
+    let usage: UsageData?
+    let error: String?
+}
+```
+
+- [ ] **Step 2: Implement store with migration**
+
+```swift
+enum AccountConfigStore {
+    static let accountsKey = "accountsV1"
+    static let legacyTokenKey = "anthropicAuthToken"
+    static func loadAccounts(userDefaults: UserDefaults = .standard) -> [AccountConfig] { ... }
+    static func saveAccounts(_ accounts: [AccountConfig], userDefaults: UserDefaults = .standard) throws { ... }
+}
+```
+
+- [ ] **Step 3: Implement combined aggregation helpers**
+
+```swift
+enum UsageAggregation {
+    static func combine(_ usages: [UsageData]) -> CombinedUsageData { ... }
+    static func tokenPercentage(from quotaLimits: QuotaLimitData?) -> Double? { ... }
+}
+```
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run: `cd ZaiUsageMenuBar && swift test`  
+Expected: PASS for migration and aggregation tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageModels.swift ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/AccountConfigStore.swift ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageAggregation.swift
+git commit -m "feat: add account store and usage aggregation logic"
+```
+
+### Task 3: Implement Multi-Account API Fetching
+
+**Files:**
+- Modify: `ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageAPIClient.swift`
+- Test: `ZaiUsageMenuBar/Tests/ZaiUsageMenuBarTests/UsageAggregationTests.swift`
+
+- [ ] **Step 1: Add per-account fetch method**
+
+```swift
+func fetchUsage(for account: AccountConfig) async throws -> UsageData
+```
+
+- [ ] **Step 2: Add concurrent bulk fetch**
+
+```swift
+func fetchAllUsage(accounts: [AccountConfig]) async -> [AccountUsageResult] {
+    await withTaskGroup(of: (Int, AccountUsageResult).self) { group in ... }
+}
+```
+
+- [ ] **Step 3: Keep ordering stable and failure isolated**
+
+```swift
+AccountUsageResult(account: account, usage: nil, error: error.localizedDescription)
+```
+
+- [ ] **Step 4: Run tests/build**
+
+Run: `cd ZaiUsageMenuBar && swift test && swift build`  
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageAPIClient.swift
+git commit -m "feat: fetch account usage concurrently with partial failure support"
+```
+
+### Task 4: Update ViewModel for Dashboard State
+
+**Files:**
+- Modify: `ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageViewModel.swift`
+- Modify: `ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/AppDelegate.swift`
+
+- [ ] **Step 1: Replace single-account state with dashboard state**
+
+```swift
+@Published var dashboard: UsageDashboardData?
+@Published var error: String?
+```
+
+- [ ] **Step 2: Implement refresh flow using account store + bulk fetch**
+
+```swift
+let accounts = AccountConfigStore.loadAccounts()
+let enabled = accounts.filter { $0.isEnabled && !$0.authToken.trimmed.isEmpty }
+let results = await UsageAPIClient.shared.fetchAllUsage(accounts: enabled)
+```
+
+- [ ] **Step 3: Aggregate successes and update status item**
+
+```swift
+let combined = UsageAggregation.combine(successes)
+AppDelegate.shared?.updateStatusItem(percentage: UsageAggregation.tokenPercentage(from: combined.quotaLimits))
+```
+
+- [ ] **Step 4: Run tests/build**
+
+Run: `cd ZaiUsageMenuBar && swift test && swift build`  
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageViewModel.swift ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/AppDelegate.swift
+git commit -m "feat: use dashboard state with combined multi-account status"
+```
+
+### Task 5: Update Settings and Popover UI
+
+**Files:**
+- Modify: `ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/SettingsView.swift`
+- Modify: `ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift`
+- Modify: `ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/Localization.swift`
+
+- [ ] **Step 1: Replace single token form with account list editor**
+
+```swift
+@State private var accounts: [AccountConfig] = []
+Button(L10n.localized("add_account")) { accounts.append(AccountConfig.newDefault()) }
+```
+
+- [ ] **Step 2: Save with validation**
+
+```swift
+guard validate(accounts) else { return }
+try AccountConfigStore.saveAccounts(accounts)
+NotificationCenter.default.post(name: .refreshUsage, object: nil)
+```
+
+- [ ] **Step 3: Render combined section + per-account section**
+
+```swift
+if let combined = viewModel.dashboard?.combined { ... }
+AccountsUsageSection(results: viewModel.dashboard?.accounts ?? [])
+```
+
+- [ ] **Step 4: Add localization keys**
+
+```swift
+"combined", "accounts", "add_account", "account_name", "enabled", "delete", "default_account_name", "no_accounts_configured", "all_accounts_failed"
+```
+
+- [ ] **Step 5: Run tests/build**
+
+Run: `cd ZaiUsageMenuBar && swift test && swift build`  
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/SettingsView.swift ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/Localization.swift
+git commit -m "feat: add multi-account settings and combined account views"
+```
+
+### Task 6: Final Verification and Wrap-Up
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Update README configuration section**
+
+```markdown
+- Add multiple named accounts in Settings
+- Combined menu bar percentage and per-account breakdown behavior
+```
+
+- [ ] **Step 2: Full verification**
+
+Run: `cd ZaiUsageMenuBar && swift test && swift build && swift run --help`  
+Expected: tests/build succeed and app remains runnable.
+
+- [ ] **Step 3: Final commit**
+
+```bash
+git add README.md
+git commit -m "docs: document multi-account configuration and behavior"
+```

--- a/docs/superpowers/specs/2026-04-04-chinese-language-support-design.md
+++ b/docs/superpowers/specs/2026-04-04-chinese-language-support-design.md
@@ -29,7 +29,7 @@ Add Simplified Chinese localization to the ZaiUsageMenuBar app using Xcode Strin
 | retry | Retry | 重试 |
 | quota | Quota | 配额 |
 | token_label | Token (5h) | Token (5小时) |
-| mcp_label | MCP (1m) | MCP (1分钟) |
+| mcp_label | MCP (1m) | MCP (1个月) |
 | resets | resets | 重置 |
 | model_usage | Model Usage | 模型用量 |
 | tools | Tools | 工具调用 |

--- a/docs/superpowers/specs/2026-04-08-multi-account-usage-design.md
+++ b/docs/superpowers/specs/2026-04-08-multi-account-usage-design.md
@@ -1,0 +1,210 @@
+# Multi-Account Usage Dashboard Design
+
+Date: 2026-04-08
+Project: `zai_usage_menu_bar`
+Status: Proposed and user-approved in brainstorming session
+
+## Goal
+
+Add support for multiple ZhiPu API accounts and show:
+
+- Combined totals across accounts
+- Per-account breakdown in the same popover
+- Partial results when some accounts fail
+
+## Scope
+
+In scope:
+
+- Multi-account storage, editing, migration, fetching, aggregation, and display
+- Combined menu bar percentage from all successful accounts
+- Per-account success/error cards
+
+Out of scope:
+
+- Account grouping/tags
+- Historical local persistence/caching
+- New endpoint integrations
+
+## Product Decisions
+
+- Display mode: combined totals plus per-account breakdown
+- Account identity: custom name + token per account
+- Backward compatibility: auto-migrate existing `anthropicAuthToken` into `Default Account`
+- Failure behavior: one failed account does not block others
+- Menu bar percentage: combined token usage percentage across successful accounts
+
+## Architecture
+
+### Data Storage
+
+Introduce `accountsV1` in `UserDefaults` as JSON-encoded array:
+
+```swift
+struct AccountConfig: Codable, Identifiable, Hashable {
+    let id: String
+    var name: String
+    var authToken: String
+    var isEnabled: Bool
+}
+```
+
+Migration rule:
+
+- If `accountsV1` is empty and legacy `anthropicAuthToken` exists and is non-empty:
+  - Create one account with:
+    - `id`: UUID string
+    - `name`: `Default Account`
+    - `authToken`: legacy token
+    - `isEnabled`: `true`
+  - Persist to `accountsV1`
+
+### Runtime Models
+
+```swift
+struct AccountUsageResult: Identifiable {
+    let account: AccountConfig
+    let usage: UsageData?
+    let error: String?
+}
+
+struct CombinedUsageData {
+    let modelUsage: ModelUsageData?
+    let toolUsage: ToolUsageData?
+    let quotaLimits: QuotaLimitData?
+}
+
+struct UsageDashboardData {
+    let combined: CombinedUsageData
+    let accounts: [AccountUsageResult]
+    let lastUpdated: Date
+}
+```
+
+## Fetching Flow
+
+1. Load and migrate account config if needed.
+2. Filter enabled accounts with non-empty token.
+3. If no valid enabled accounts exist, publish a settings-focused error state (no network calls).
+4. Fetch each account using existing endpoints and auth header.
+5. Perform concurrent account requests with task groups.
+6. Store success or error per account; do not fail whole refresh on partial errors.
+7. Aggregate successful account payloads into combined totals.
+8. Publish dashboard state and update menu bar percentage from combined token limit.
+
+## Aggregation Rules
+
+Only successful accounts contribute to combined totals.
+
+### Quota Limits
+
+For each limit type (`TOKENS_LIMIT`, `TIME_LIMIT`):
+
+- `currentValue`: sum of per-account `currentValue`
+- `usage`: sum of per-account `usage`
+- `percentage`: recompute from totals (`sumCurrent / sumUsage * 100`) when denominator > 0
+- `nextResetTime`: earliest non-nil reset time among contributors
+
+### Model Usage
+
+- `totalModelCallCount`: sum
+- `totalTokensUsage`: sum
+
+### Tool Usage
+
+- Sum top-level totals:
+  - `totalNetworkSearchCount`
+  - `totalWebReadMcpCount`
+  - `totalZreadMcpCount`
+  - `totalSearchMcpCount`
+- Merge `toolDetails` by `modelName` and sum `totalUsageCount`
+
+### Menu Bar
+
+Status item title shows combined `TOKENS_LIMIT` percentage (rounded whole number).
+If unavailable (no successful token quota data), show `--`.
+
+## UI Design
+
+### Settings
+
+Replace single token field with account editor:
+
+- Account rows with:
+  - Name text field
+  - Token secure field
+  - Enabled toggle
+  - Delete button
+- Add account button
+- Validation:
+  - Name required after trimming
+  - Enabled account must have non-empty token
+
+### Popover
+
+Order:
+
+1. Header (existing controls)
+2. Combined section (existing quota/model/tools cards fed by aggregated data)
+3. Accounts section (one compact card per account):
+  - Name
+  - Success summary (token percent, tokens, calls), or
+  - Per-account error message
+
+Error handling:
+
+- If all accounts fail, show global error and per-account error cards.
+- If some accounts succeed, show combined data and failed account errors side by side.
+- If no enabled account is configured, show a clear "configure accounts in settings" state.
+
+## Implementation Plan (Code Areas)
+
+- `UsageModels.swift`
+  - Add account and dashboard runtime models
+- `SettingsView.swift`
+  - Account list management UI and persistence helpers
+- `UsageAPIClient.swift`
+  - Per-account fetch and concurrent multi-account fetch
+  - Aggregation utility
+- `UsageViewModel.swift`
+  - Dashboard-driven state and refresh orchestration
+- `MenuBarContentView.swift`
+  - Combined + account breakdown rendering
+- `Localization.swift`
+  - New strings for account management and combined/account labels
+- `AppDelegate.swift`
+  - Keep status item update API; feed combined percentage from view model logic
+
+## Testing Strategy
+
+1. Migration
+- Legacy token migrates into a single `Default Account` entry.
+
+2. Aggregation
+- Multiple successful accounts aggregate correctly for quota/model/tool totals.
+- `toolDetails` merges by model name.
+
+3. Partial failure
+- One account failure does not block combined results from successful accounts.
+- Failed account remains visible with explicit error.
+
+4. UI smoke
+- Add/edit/delete account works and persists.
+- Popover shows combined section and per-account cards.
+
+## Risks and Mitigations
+
+- Risk: token leakage in logs or debug text
+  - Mitigation: never print token; store and display masked/secure fields only.
+- Risk: larger settings complexity
+  - Mitigation: keep compact list UI and lightweight validation feedback.
+- Risk: inconsistent combined percentages if payload fields are missing
+  - Mitigation: aggregate defensively with nil-aware math and denominator checks.
+
+## Acceptance Criteria
+
+- User can add multiple accounts with custom names and tokens.
+- Existing single-token users are automatically migrated.
+- Popover shows combined usage and per-account breakdown together.
+- Failed accounts show errors without hiding successful account data.
+- Menu bar percentage reflects combined token usage.


### PR DESCRIPTION
## Summary

- Support configuring multiple named API accounts in settings
- Show combined totals and per-account usage in the popover
- Individual account failures no longer block the UI
- Proper code signing for the build script (prefers real certificate, ad-hoc opt-in)
- Fix MCP label translation (1分钟 → 1个月)

## Keychain Prompt Fix

After upgrading from a previous version, you may see repeated Keychain prompts because the old single-token entry conflicts with the new per-account storage. Run this to clean it up:

```bash
SERVICE="com.benjamin.zai-usage-menu-bar.auth-token"
KEYCHAIN="$HOME/Library/Keychains/login.keychain-db"

while security delete-generic-password -s "$SERVICE" "$KEYCHAIN" >/dev/null 2>&1; do :; done
echo "done"
```

Then rebuild and relaunch:

```bash
cd ZaiUsageMenuBar
security find-identity -v -p codesigning
SIGNING_IDENTITY="Apple Development: Your Name (TEAMID)" ./build-app.sh
open .build/release/ZaiUsageMenuBar.app
```

Closes #1