### PR TITLE
Redesign: multi-account UI with collapsible sections

### DIFF
--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
@@ -222,7 +222,7 @@ struct QuotaLimitsView: View {
             }
         }
         .padding(8)
-        .background(Color(NSColor.controlBackgroundColor))
+        .background(Color.white.opacity(0.10))
         .cornerRadius(6)
     }
 
@@ -317,7 +317,7 @@ struct ModelUsageView: View {
             }
         }
         .padding(8)
-        .background(Color(NSColor.controlBackgroundColor))
+        .background(Color.white.opacity(0.10))
         .cornerRadius(6)
     }
 }
@@ -353,7 +353,7 @@ struct ToolUsageView: View {
             }
         }
         .padding(8)
-        .background(Color(NSColor.controlBackgroundColor))
+        .background(Color.white.opacity(0.10))
         .cornerRadius(6)
     }
 }


### PR DESCRIPTION
## Summary
- Redesign the menu bar popover UI with collapsible per-account sections
- Update UsageViewModel to use per-account data without aggregation
- Remove unused combine methods from UsageAggregation
- Use non-deprecated onChange API for macOS 14+
- Remove unused localization keys
- Lighten card backgrounds for better dark mode visibility

## Test plan
- [ ] Verify popover shows per-account collapsible sections
- [ ] Verify card backgrounds have proper contrast in dark mode
- [ ] Verify token/MCP usage data displays correctly per account
- [ ] Verify settings and refresh still work