### PR TITLE
feat: native macOS UI redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .build/
 .DS_Store
+.superpowers/

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/AccountConfigStore.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/AccountConfigStore.swift
@@ -163,7 +163,8 @@ private struct KeychainAuthTokenStore: AuthTokenStore {
         var query = baseQuery(for: accountID)
         query[kSecReturnData as String] = true
         query[kSecMatchLimit as String] = kSecMatchLimitOne
-        
+        query[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUIFail
+
         var item: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &item)
         guard status == errSecSuccess,
@@ -172,30 +173,34 @@ private struct KeychainAuthTokenStore: AuthTokenStore {
         else {
             return nil
         }
-        
+
         return token
     }
-    
+
     func setAuthToken(_ token: String, for accountID: String) throws {
         let data = Data(token.utf8)
         let query = baseQuery(for: accountID)
-        let attributes = [kSecValueData as String: data]
+        let attributes: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
         let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
-        
+
         if updateStatus == errSecSuccess {
             return
         }
-        
+
         if updateStatus == errSecItemNotFound {
-            var item = query
+            var item: [String: Any] = baseQuery(for: accountID)
             item[kSecValueData as String] = data
+            item[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
             let addStatus = SecItemAdd(item as CFDictionary, nil)
             guard addStatus == errSecSuccess else {
                 throw AccountConfigStoreError.keychainError(status: addStatus)
             }
             return
         }
-        
+
         throw AccountConfigStoreError.keychainError(status: updateStatus)
     }
     

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/AppDelegate.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/AppDelegate.swift
@@ -21,6 +21,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let contentView = MenuBarContentView()
         popover.contentSize = NSSize(width: 300, height: 360)
         popover.behavior = .transient
+        popover.appearance = NSAppearance(named: .darkAqua)
         popover.contentViewController = NSHostingController(rootView: contentView)
         
         refreshTimer = Timer(timeInterval: 300, repeats: true) { _ in

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
@@ -16,9 +16,10 @@ struct MenuBarContentView: View {
                     }
 
                     if let dashboard = viewModel.dashboard {
-                        ForEach(dashboard.accounts) { result in
+                        ForEach(Array(dashboard.accounts.enumerated()), id: \.element.id) { index, result in
                             AccountSectionView(
                                 result: result,
+                                colorIndex: index,
                                 isExpanded: expandedAccounts.contains(result.id),
                                 onToggle: { toggleAccount(result.id) }
                             )
@@ -175,7 +176,7 @@ struct TokenRingView: View {
             Circle()
                 .trim(from: 0, to: percentage / 100)
                 .stroke(color, style: StrokeStyle(lineWidth: 2, lineCap: .round))
-                .rotation(.degrees(-90))
+                .rotationEffect(.degrees(-90))
             Text(String(format: "%.0f", percentage))
                 .font(.system(size: size * 0.3, weight: .bold))
                 .foregroundColor(color)
@@ -186,135 +187,132 @@ struct TokenRingView: View {
 
 struct AccountSectionView: View {
     let result: AccountUsageResult
+    let colorIndex: Int
     let isExpanded: Bool
     let onToggle: () -> Void
 
-    private var tokenPercentage: Double? {
-        UsageAggregation.tokenPercentage(from: result.usage?.quotaLimits)
+    private var accentColor: Color { accountColor(for: colorIndex) }
+
+    private var ringPercentageValue: Double? {
+        UsageAggregation.ringPercentage(from: result.usage?.quotaLimits)
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header row
             Button(action: onToggle) {
-                HStack(spacing: 4) {
+                HStack(spacing: 6) {
                     Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                        .font(.system(size: 10))
+                        .font(.system(size: 9))
                         .foregroundColor(.secondary)
+                        .frame(width: 10)
+
                     Text(result.account.displayName)
-                        .font(.caption)
-                        .fontWeight(.semibold)
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(.primary.opacity(0.85))
+
+                    if let level = result.usage?.quotaLimits.level {
+                        Text(level.uppercased())
+                            .font(.system(size: 8))
+                            .foregroundColor(.secondary.opacity(0.6))
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(Color.secondary.opacity(0.1))
+                            .cornerRadius(3)
+                    }
+
                     Spacer()
-                    if let tokenPercentage = tokenPercentage {
-                        Text(String(format: "%.0f%%", tokenPercentage))
-                            .font(.caption2)
-                            .fontWeight(.semibold)
-                            .foregroundColor(progressColor(for: tokenPercentage))
+
+                    if let pct = ringPercentageValue {
+                        TokenRingView(
+                            percentage: pct,
+                            color: progressColor(for: pct, accountAccent: accentColor),
+                            size: 24
+                        )
                     }
                 }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
             }
             .buttonStyle(.plain)
 
+            // Expanded content
             if isExpanded {
-                if let usage = result.usage {
-                    if let limits = usage.quotaLimits.limits, !limits.isEmpty {
-                        QuotaLimitsView(quotaData: usage.quotaLimits)
+                VStack(alignment: .leading, spacing: 0) {
+                    if let usage = result.usage {
+                        if let limits = usage.quotaLimits.limits, !limits.isEmpty {
+                            QuotaSectionView(quotaData: usage.quotaLimits, accentColor: accentColor)
+                        }
+                        if usage.modelUsage.totalUsage != nil || usage.toolUsage.totalUsage != nil {
+                            StatsSectionView(usage: usage, accentColor: accentColor)
+                        }
+                    } else if let error = result.error {
+                        Text(error)
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                            .lineLimit(3)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
                     }
-
-                    if usage.modelUsage.totalUsage != nil {
-                        ModelUsageView(modelData: usage.modelUsage)
-                    }
-
-                    if usage.toolUsage.totalUsage != nil {
-                        ToolUsageView(toolData: usage.toolUsage)
-                    }
-                } else if let error = result.error {
-                    Text(error)
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                        .lineLimit(3)
                 }
             }
         }
+        .background(Color.primary.opacity(0.05))
+        .cornerRadius(10)
     }
 }
 
-struct QuotaLimitsView: View {
+struct QuotaSectionView: View {
     let quotaData: QuotaLimitData
+    let accentColor: Color
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack {
-                Text(L10n.localized("quota"))
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                Spacer()
-                if let level = quotaData.level {
-                    Text(level.uppercased())
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                        .padding(.horizontal, 4)
-                        .padding(.vertical, 1)
-                        .background(Color.secondary.opacity(0.15))
-                        .cornerRadius(3)
+        VStack(alignment: .leading, spacing: 4) {
+            if let limits = quotaData.limits, !limits.isEmpty {
+                ForEach(Array(limits.enumerated()), id: \.offset) { _, limit in
+                    QuotaBarRow(limit: limit, accentColor: accentColor)
                 }
             }
-
-            ForEach(Array(quotaData.limits?.enumerated() ?? [].enumerated()), id: \.offset) { _, limit in
-                QuotaLimitRow(limit: limit, label: labelForLimit(limit))
-            }
         }
-        .padding(8)
-        .background(Color.white.opacity(0.10))
-        .cornerRadius(6)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
     }
+}
 
-    private func labelForLimit(_ limit: QuotaLimit) -> String {
+private struct QuotaBarRow: View {
+    let limit: QuotaLimit
+    let accentColor: Color
+
+    private var label: String {
         if limit.type == "TOKENS_LIMIT" {
-            if limit.unit == 6 { return L10n.localized("weekly_token_label") }
-            return L10n.localized("token_label")
+            return limit.unit == 6 ? L10n.localized("weekly_token_label") : L10n.localized("token_label")
         }
-        if limit.type == "TIME_LIMIT" {
-            return L10n.localized("mcp_label")
-        }
+        if limit.type == "TIME_LIMIT" { return L10n.localized("mcp_label") }
         return limit.type ?? ""
     }
-}
 
-struct QuotaLimitRow: View {
-    let limit: QuotaLimit
-    let label: String
-
-    var resetDate: Date? {
-        guard let nextResetTime = limit.nextResetTime else { return nil }
-        return Date(timeIntervalSince1970: nextResetTime / 1000)
+    private var resetDate: Date? {
+        guard let t = limit.nextResetTime else { return nil }
+        return Date(timeIntervalSince1970: t / 1000)
     }
 
     var body: some View {
-        let color = progressColor(for: limit.percentage)
-        return VStack(alignment: .leading, spacing: 3) {
+        let color = progressColor(for: limit.percentage, accountAccent: accentColor)
+        VStack(alignment: .leading, spacing: 2) {
             HStack {
                 Text(label)
-                    .font(.caption2)
-                    .foregroundColor(.secondary)
-
+                    .font(.system(size: 9))
+                    .foregroundColor(.secondary.opacity(0.7))
                 Spacer()
-
                 if let current = limit.currentValue, let usage = limit.usage {
                     Text(String(format: "%.0f/%.0f", current, usage))
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                }
-
-                if let percentage = limit.percentage {
-                    Text(String(format: "%.0f%%", percentage))
-                        .font(.caption2)
-                        .fontWeight(.semibold)
-                        .foregroundColor(color)
+                        .font(.system(size: 9))
+                        .foregroundColor(.secondary.opacity(0.5))
                 }
             }
 
-            if let percentage = limit.percentage {
-                ProgressView(value: min(percentage, 100), total: 100)
+            if let pct = limit.percentage {
+                ProgressView(value: min(pct, 100), total: 100)
                     .progressViewStyle(LinearProgressViewStyle(tint: color))
                     .frame(height: 3)
             }
@@ -322,81 +320,80 @@ struct QuotaLimitRow: View {
             if let resetDate = resetDate {
                 HStack {
                     Spacer()
-                    Image(systemName: "clock")
-                        .font(.caption2)
                     Text("\(L10n.localized("resets_prefix")) \(resetDate, style: .relative)")
-                        .font(.caption2)
-                }
-                .foregroundColor(Color.secondary)
-            }
-        }
-    }
-}
-
-struct ModelUsageView: View {
-    let modelData: ModelUsageData
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack {
-                Text(L10n.localized("model_usage"))
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                Spacer()
-                if let totalUsage = modelData.totalUsage, let tokens = totalUsage.totalTokensUsage {
-                    Text(formatTokenCount(tokens))
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                }
-            }
-
-            if let totalUsage = modelData.totalUsage, let calls = totalUsage.totalModelCallCount {
-                HStack(spacing: 12) {
-                    Label("\(calls)", systemImage: "bubble.left")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
+                        .font(.system(size: 8))
+                        .foregroundColor(.secondary.opacity(0.4))
                 }
             }
         }
-        .padding(8)
-        .background(Color.white.opacity(0.10))
-        .cornerRadius(6)
+        .padding(.bottom, 2)
     }
 }
 
-struct ToolUsageView: View {
-    let toolData: ToolUsageData
+struct StatsSectionView: View {
+    let usage: UsageData
+    let accentColor: Color
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack {
-                Text(L10n.localized("tools"))
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                Spacer()
-                if let totalUsage = toolData.totalUsage, let searchCount = totalUsage.totalSearchMcpCount {
-                    Text("\(searchCount) \(L10n.localized("calls_suffix"))")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
+        VStack(spacing: 0) {
+            Divider()
+                .background(Color.primary.opacity(0.05))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+
+            // Main stats row
+            HStack(spacing: 0) {
+                if let calls = usage.modelUsage.totalUsage?.totalModelCallCount {
+                    StatColumn(value: "\(calls)", label: "Model Calls")
+                    Spacer()
+                }
+                if let totalTools = usage.toolUsage.totalUsage?.totalSearchMcpCount {
+                    StatColumn(value: "\(totalTools)", label: "Tool Calls")
+                    Spacer()
+                }
+                if let tokens = usage.modelUsage.totalUsage?.totalTokensUsage {
+                    StatColumn(value: formatTokenCount(tokens), label: "Tokens")
                 }
             }
+            .padding(.horizontal, 10)
+            .padding(.bottom, 6)
 
-            if let toolDetails = toolData.totalUsage?.toolDetails, !toolDetails.isEmpty {
-                ForEach(Array(toolDetails.enumerated()), id: \.offset) { _, detail in
-                    HStack {
-                        Text(detail.modelName ?? "")
-                            .font(.caption2)
-                        Spacer()
-                        Text("\(detail.totalUsageCount ?? 0)")
-                            .font(.caption2)
-                            .fontWeight(.medium)
+            // Tool breakdown
+            if let details = usage.toolUsage.totalUsage?.toolDetails, !details.isEmpty {
+                VStack(spacing: 2) {
+                    ForEach(details, id: \.self) { detail in
+                        HStack {
+                            Text(detail.modelName ?? "")
+                                .font(.system(size: 9))
+                                .foregroundColor(.primary.opacity(0.35))
+                            Spacer()
+                            Text("\(detail.totalUsageCount ?? 0)")
+                                .font(.system(size: 9))
+                                .fontWeight(.medium)
+                                .foregroundColor(.primary.opacity(0.45))
+                        }
                     }
                 }
+                .padding(.horizontal, 10)
+                .padding(.bottom, 8)
             }
         }
-        .padding(8)
-        .background(Color.white.opacity(0.10))
-        .cornerRadius(6)
+    }
+}
+
+private struct StatColumn: View {
+    let value: String
+    let label: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(value)
+                .font(.system(size: 15, weight: .bold))
+                .foregroundColor(.primary.opacity(0.9))
+            Text(label)
+                .font(.system(size: 8))
+                .foregroundColor(.primary.opacity(0.3))
+        }
     }
 }
 

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
@@ -298,7 +298,7 @@ private struct QuotaBarRow: View {
 
     var body: some View {
         let color = progressColor(for: limit.percentage, accountAccent: accentColor)
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: 4) {
             HStack {
                 Text(label)
                     .font(.system(size: 9))
@@ -324,9 +324,10 @@ private struct QuotaBarRow: View {
                         .font(.system(size: 8))
                         .foregroundColor(.secondary.opacity(0.4))
                 }
+                .padding(.top, 1)
             }
         }
-        .padding(.bottom, 2)
+        .padding(.bottom, 4)
     }
 }
 

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
@@ -70,6 +70,21 @@ struct HeaderView: View {
 
     var body: some View {
         HStack(spacing: 6) {
+            AsyncImage(url: URL(string: "https://z-cdn.chatglm.cn/z-ai/static/logo.svg")) { phase in
+                if let image = phase.image {
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                } else {
+                    Text("Z")
+                        .font(.system(size: 10, weight: .bold))
+                        .frame(width: 20, height: 20)
+                        .background(Color.white.opacity(0.1))
+                        .cornerRadius(5)
+                }
+            }
+            .frame(width: 20, height: 20)
+
             Text(L10n.localized("app_title"))
                 .font(.subheadline)
                 .fontWeight(.semibold)

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
@@ -358,15 +358,28 @@ struct ToolUsageView: View {
     }
 }
 
+private let accountColorPalette: [Color] = [
+    Color(red: 10/255, green: 132/255, blue: 1),      // Blue #0a84ff
+    Color(red: 255/255, green: 159/255, blue: 10/255), // Orange #ff9f0a
+    Color(red: 48/255, green: 209/255, blue: 88/255),  // Green #30d158
+    Color(red: 94/255, green: 92/255, blue: 230/255),  // Purple #5e5ce6
+    Color(red: 100/255, green: 210/255, blue: 255/255),// Cyan #64d2ff
+    Color(red: 255/255, green: 55/255, blue: 95/255),  // Pink #ff375f
+]
+
+func accountColor(for index: Int) -> Color {
+    accountColorPalette[index % accountColorPalette.count]
+}
+
+func progressColor(for percentage: Double?, accountAccent: Color) -> Color {
+    guard let percentage else { return accountAccent }
+    if percentage >= 90 { return Color(red: 255/255, green: 69/255, blue: 58/255) }
+    if percentage >= 70 { return Color(red: 255/255, green: 159/255, blue: 10/255) }
+    return accountAccent
+}
+
 func formatTokenCount(_ count: Int) -> String {
     if count >= 1_000_000 { return String(format: "%.1fM", Double(count) / 1_000_000) }
     if count >= 1_000 { return String(format: "%.1fK", Double(count) / 1_000) }
     return "\(count)"
-}
-
-func progressColor(for percentage: Double?) -> Color {
-    guard let percentage else { return .green }
-    if percentage >= 90 { return .red }
-    if percentage >= 70 { return .orange }
-    return .green
 }

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
@@ -142,6 +142,33 @@ struct ErrorView: View {
     }
 }
 
+struct TokenRingView: View {
+    let percentage: Double
+    let color: Color
+    let size: CGFloat
+
+    init(percentage: Double, color: Color, size: CGFloat = 24) {
+        self.percentage = min(max(percentage, 0), 100)
+        self.color = color
+        self.size = size
+    }
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.white.opacity(0.08), lineWidth: 2)
+            Circle()
+                .trim(from: 0, to: percentage / 100)
+                .stroke(color, style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                .rotation(.degrees(-90))
+            Text(String(format: "%.0f", percentage))
+                .font(.system(size: size * 0.3, weight: .bold))
+                .foregroundColor(color)
+        }
+        .frame(width: size, height: size)
+    }
+}
+
 struct AccountSectionView: View {
     let result: AccountUsageResult
     let isExpanded: Bool

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageAggregation.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageAggregation.swift
@@ -6,6 +6,16 @@ enum UsageAggregation {
         return percentage(for: tokenLimit)
     }
 
+    static func ringPercentage(from quotaLimits: QuotaLimitData?) -> Double? {
+        guard let limits = quotaLimits?.limits else { return nil }
+        // Prefer 5h window (TOKENS_LIMIT where unit != 6)
+        let limit5h = limits.first { $0.type == "TOKENS_LIMIT" && $0.unit != 6 }
+        if let limit5h { return percentage(for: limit5h) }
+        // Fallback to weekly (unit == 6)
+        let limitWeekly = limits.first { $0.type == "TOKENS_LIMIT" && $0.unit == 6 }
+        return percentage(for: limitWeekly)
+    }
+
     private static func percentage(for limit: QuotaLimit?) -> Double? {
         guard let limit else { return nil }
         if let percentage = limit.percentage {

--- a/ZaiUsageMenuBar/Tests/ZaiUsageMenuBarTests/UsageAggregationTests.swift
+++ b/ZaiUsageMenuBar/Tests/ZaiUsageMenuBarTests/UsageAggregationTests.swift
@@ -71,3 +71,38 @@ final class UsageAggregationTests: XCTestCase {
         XCTAssertNil(UsageAggregation.tokenPercentage(from: nil))
     }
 }
+
+extension UsageAggregationTests {
+    func testRingPercentage5hPreferred() {
+        let limit5h = QuotaLimit(
+            type: "TOKENS_LIMIT", unit: nil, number: nil,
+            usage: 100000, currentValue: 10000, remaining: nil,
+            percentage: 10.0, nextResetTime: nil, usageDetails: nil
+        )
+        let limitWeekly = QuotaLimit(
+            type: "TOKENS_LIMIT", unit: 6, number: nil,
+            usage: 500000, currentValue: 50000, remaining: nil,
+            percentage: 10.0, nextResetTime: nil, usageDetails: nil
+        )
+        let data = QuotaLimitData(limits: [limit5h, limitWeekly], level: nil)
+        let result = UsageAggregation.ringPercentage(from: data)
+        XCTAssertEqual(result, 10.0)
+    }
+
+    func testRingPercentageFallsBackToWeekly() {
+        let limitWeekly = QuotaLimit(
+            type: "TOKENS_LIMIT", unit: 6, number: nil,
+            usage: 500000, currentValue: 50000, remaining: nil,
+            percentage: 10.0, nextResetTime: nil, usageDetails: nil
+        )
+        let data = QuotaLimitData(limits: [limitWeekly], level: nil)
+        let result = UsageAggregation.ringPercentage(from: data)
+        XCTAssertEqual(result, 10.0)
+    }
+
+    func testRingPercentageNilWhenNoTokenLimits() {
+        let data = QuotaLimitData(limits: [], level: nil)
+        let result = UsageAggregation.ringPercentage(from: data)
+        XCTAssertNil(result)
+    }
+}

--- a/ZaiUsageMenuBar/build-app.sh
+++ b/ZaiUsageMenuBar/build-app.sh
@@ -97,5 +97,17 @@ if [[ -z "$SIGNING_IDENTITY" ]]; then
     fi
 fi
 
-codesign --force --deep --sign "$SIGNING_IDENTITY" --options runtime --timestamp=none "$APP_BUNDLE"
+# Resolve the keychain containing the signing identity to avoid repeated unlock prompts
+SIGNING_KEYCHAIN=""
+if [[ "$SIGNING_IDENTITY" != "-" ]]; then
+    # Find which keychain holds this identity
+    SIGNING_KEYCHAIN=$(security find-identity -v -p codesigning | grep -F "\"$SIGNING_IDENTITY\"" | head -1 | grep -oE '/[^ "]+\.keychain-db' | head -1)
+fi
+
+CODESIGN_ARGS=(--force --deep --sign "$SIGNING_IDENTITY" --options runtime --timestamp=none)
+if [[ -n "$SIGNING_KEYCHAIN" ]]; then
+    CODESIGN_ARGS+=(--keychain "$SIGNING_KEYCHAIN")
+fi
+
+codesign "${CODESIGN_ARGS[@]}" "$APP_BUNDLE"
 echo "App bundle signed with identity: $SIGNING_IDENTITY"

--- a/docs/superpowers/plans/2026-04-09-native-ui-redesign.md
+++ b/docs/superpowers/plans/2026-04-09-native-ui-redesign.md
@@ -1,0 +1,679 @@
+# Native UI Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the menu bar app UI to use native macOS styling with Apple system colors, circular progress rings, and compact stat rows.
+
+**Architecture:** The redesign is confined to `MenuBarContentView.swift` — all views are in this single file. We add a `TokenRingView` component, a color palette helper, restructure `AccountSectionView` to inline quota/stats/tools, and remove the separate `QuotaLimitsView`, `ModelUsageView`, `ToolUsageView` sections. A new helper in `UsageAggregation` extracts the 5h/weekly ring percentage. The ZAI logo SVG is downloaded as an asset.
+
+**Tech Stack:** SwiftUI (macOS 14+), Swift 5.9
+
+---
+
+### Task 1: Add 5h Ring Percentage Helper
+
+**Files:**
+- Modify: `ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageAggregation.swift`
+- Test: `ZaiUsageMenuBar/Tests/ZaiUsageMenuBarTests/UsageAggregationTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// In UsageAggregationTests.swift — add these tests to the existing file
+
+extension UsageAggregationTests {
+    func testRingPercentage5hPreferred() {
+        let limit5h = QuotaLimit(
+            type: "TOKENS_LIMIT", unit: nil, number: nil,
+            usage: 100000, currentValue: 10000, remaining: nil,
+            percentage: 10.0, nextResetTime: nil, usageDetails: nil
+        )
+        let limitWeekly = QuotaLimit(
+            type: "TOKENS_LIMIT", unit: 6, number: nil,
+            usage: 500000, currentValue: 50000, remaining: nil,
+            percentage: 10.0, nextResetTime: nil, usageDetails: nil
+        )
+        let data = QuotaLimitData(limits: [limit5h, limitWeekly], level: nil)
+        let result = UsageAggregation.ringPercentage(from: data)
+        XCTAssertEqual(result, 10.0)
+    }
+
+    func testRingPercentageFallsBackToWeekly() {
+        let limitWeekly = QuotaLimit(
+            type: "TOKENS_LIMIT", unit: 6, number: nil,
+            usage: 500000, currentValue: 50000, remaining: nil,
+            percentage: 10.0, nextResetTime: nil, usageDetails: nil
+        )
+        let data = QuotaLimitData(limits: [limitWeekly], level: nil)
+        let result = UsageAggregation.ringPercentage(from: data)
+        XCTAssertEqual(result, 10.0)
+    }
+
+    func testRingPercentageNilWhenNoTokenLimits() {
+        let data = QuotaLimitData(limits: [], level: nil)
+        let result = UsageAggregation.ringPercentage(from: data)
+        XCTAssertNil(result)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/benjamin/tools/zai_usage_menu_bar/ZaiUsageMenuBar && swift test --filter UsageAggregationTests 2>&1 | tail -20`
+Expected: FAIL — `ringPercentage` method does not exist
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `UsageAggregation.swift`, add this method after the existing `tokenPercentage(from:)`:
+
+```swift
+static func ringPercentage(from quotaLimits: QuotaLimitData?) -> Double? {
+    guard let limits = quotaLimits?.limits else { return nil }
+    // Prefer 5h window (TOKENS_LIMIT where unit != 6)
+    let limit5h = limits.first { $0.type == "TOKENS_LIMIT" && $0.unit != 6 }
+    if let limit5h { return percentage(for: limit5h) }
+    // Fallback to weekly (unit == 6)
+    let limitWeekly = limits.first { $0.type == "TOKENS_LIMIT" && $0.unit == 6 }
+    return percentage(for: limitWeekly)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/benjamin/tools/zai_usage_menu_bar/ZaiUsageMenuBar && swift test --filter UsageAggregationTests 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageAggregation.swift ZaiUsageMenuBar/Tests/ZaiUsageMenuBarTests/UsageAggregationTests.swift
+git commit -m "feat: add ringPercentage helper for 5h/weekly fallback"
+```
+
+---
+
+### Task 2: Add Account Color Palette Helper
+
+**Files:**
+- Modify: `ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift`
+
+This adds the color palette helper used by all subsequent tasks.
+
+- [ ] **Step 1: Add the helper function**
+
+At the bottom of `MenuBarContentView.swift`, replace the existing `progressColor(for:)` and `formatTokenCount` with:
+
+```swift
+private let accountColorPalette: [Color] = [
+    Color(red: 10/255, green: 132/255, blue: 1),      // Blue #0a84ff
+    Color(red: 255/255, green: 159/255, blue: 10/255), // Orange #ff9f0a
+    Color(red: 48/255, green: 209/255, blue: 88/255),  // Green #30d158
+    Color(red: 94/255, green: 92/255, blue: 230/255),  // Purple #5e5ce6
+    Color(red: 100/255, green: 210/255, blue: 255/255),// Cyan #64d2ff
+    Color(red: 255/255, green: 55/255, blue: 95/255),  // Pink #ff375f
+]
+
+func accountColor(for index: Int) -> Color {
+    accountColorPalette[index % accountColorPalette.count]
+}
+
+func progressColor(for percentage: Double?, accountAccent: Color) -> Color {
+    guard let percentage else { return accountAccent }
+    if percentage >= 90 { return Color(red: 255/255, green: 69/255, blue: 58/255) }
+    if percentage >= 70 { return Color(red: 255/255, green: 159/255, blue: 10/255) }
+    return accountAccent
+}
+
+func formatTokenCount(_ count: Int) -> String {
+    if count >= 1_000_000 { return String(format: "%.1fM", Double(count) / 1_000_000) }
+    if count >= 1_000 { return String(format: "%.1fK", Double(count) / 1_000) }
+    return "\(count)"
+}
+```
+
+Note: the old `progressColor(for:) -> Color` (no accent parameter) is removed. All callers will be updated in later tasks.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
+git commit -m "feat: add Apple system color palette and account color helper"
+```
+
+---
+
+### Task 3: Add TokenRingView Component
+
+**Files:**
+- Modify: `ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift`
+
+- [ ] **Step 1: Add TokenRingView**
+
+Add this struct in `MenuBarContentView.swift` before `AccountSectionView`:
+
+```swift
+struct TokenRingView: View {
+    let percentage: Double
+    let color: Color
+    let size: CGFloat
+
+    init(percentage: Double, color: Color, size: CGFloat = 24) {
+        self.percentage = min(max(percentage, 0), 100)
+        self.color = color
+        self.size = size
+    }
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.white.opacity(0.08), lineWidth: 2)
+            Circle()
+                .trim(from: 0, to: percentage / 100)
+                .stroke(color, style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                .rotation(.degrees(-90))
+            Text(String(format: "%.0f", percentage))
+                .font(.system(size: size * 0.3, weight: .bold))
+                .foregroundColor(color)
+        }
+        .frame(width: size, height: size)
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
+git commit -m "feat: add TokenRingView circular progress component"
+```
+
+---
+
+### Task 4: Download and Add ZAI Logo Asset
+
+**Files:**
+- Create: `ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/Assets.xcassets/AppIcon.appiconset/` (already exists)
+- Modify: Add logo image data
+
+- [ ] **Step 1: Download the logo**
+
+Run:
+```bash
+curl -sL "https://z-cdn.chatglm.cn/z-ai/static/logo.svg" -o /tmp/zai-logo.svg
+```
+
+Since SwiftUI cannot directly render SVGs from asset catalogs without Xcode's SVG support, and this is a Swift Package Manager project, we'll use an `AsyncImage` or convert to PNG. The simplest approach for a menu bar app is to load the logo from a remote URL at runtime using `AsyncImage` in the header.
+
+- [ ] **Step 2: Update HeaderView to use AsyncImage for logo**
+
+Replace the `HeaderView` with:
+
+```swift
+struct HeaderView: View {
+    let lastUpdated: Date?
+    let isLoading: Bool
+    @Binding var showSettings: Bool
+    var onRefresh: (() -> Void)?
+
+    var body: some View {
+        HStack(spacing: 6) {
+            AsyncImage(url: URL(string: "https://z-cdn.chatglm.cn/z-ai/static/logo.svg")) { phase in
+                if let image = phase.image {
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                } else {
+                    Text("Z")
+                        .font(.system(size: 10, weight: .bold))
+                        .frame(width: 20, height: 20)
+                        .background(Color.white.opacity(0.1))
+                        .cornerRadius(5)
+                }
+            }
+            .frame(width: 20, height: 20)
+
+            Text(L10n.localized("app_title"))
+                .font(.subheadline)
+                .fontWeight(.semibold)
+
+            Spacer()
+
+            if isLoading {
+                ProgressView()
+                    .scaleEffect(0.6)
+            }
+
+            if let lastUpdated = lastUpdated {
+                Text(lastUpdated, style: .time)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+
+            Button {
+                onRefresh?()
+            } label: {
+                Image(systemName: "arrow.clockwise")
+                    .font(.system(size: 12))
+            }
+            .buttonStyle(.plain)
+            .help(L10n.localized("refresh"))
+
+            Button {
+                showSettings = true
+            } label: {
+                Image(systemName: "gearshape")
+                    .font(.system(size: 12))
+            }
+            .buttonStyle(.plain)
+            .help(L10n.localized("settings"))
+
+            Button {
+                NSApp.terminate(nil)
+            } label: {
+                Image(systemName: "xmark.circle")
+                    .font(.system(size: 12))
+            }
+            .buttonStyle(.plain)
+            .help(L10n.localized("quit"))
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+    }
+}
+```
+
+- [ ] **Step 3: Build to verify**
+
+Run: `cd /Users/benjamin/tools/zai_usage_menu_bar/ZaiUsageMenuBar && swift build 2>&1 | tail -10`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
+git commit -m "feat: use ZAI logo in header via AsyncImage"
+```
+
+---
+
+### Task 5: Redesign AccountSectionView (Header + Ring)
+
+**Files:**
+- Modify: `ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift`
+
+This task replaces the `AccountSectionView` header to use `TokenRingView`, account colors, and the level badge. It also passes `colorIndex` down to sub-views.
+
+- [ ] **Step 1: Rewrite AccountSectionView**
+
+Replace the entire `AccountSectionView` struct with:
+
+```swift
+struct AccountSectionView: View {
+    let result: AccountUsageResult
+    let colorIndex: Int
+    let isExpanded: Bool
+    let onToggle: () -> Void
+
+    private var accentColor: Color { accountColor(for: colorIndex) }
+
+    private var ringPercentageValue: Double? {
+        UsageAggregation.ringPercentage(from: result.usage?.quotaLimits)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header row
+            Button(action: onToggle) {
+                HStack(spacing: 6) {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 9))
+                        .foregroundColor(.secondary)
+                        .frame(width: 10)
+
+                    Text(result.account.displayName)
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(.primary.opacity(0.85))
+
+                    if let level = result.usage?.quotaLimits.level {
+                        Text(level.uppercased())
+                            .font(.system(size: 8))
+                            .foregroundColor(.secondary.opacity(0.6))
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(Color.secondary.opacity(0.1))
+                            .cornerRadius(3)
+                    }
+
+                    Spacer()
+
+                    if let pct = ringPercentageValue {
+                        TokenRingView(
+                            percentage: pct,
+                            color: progressColor(for: pct, accountAccent: accentColor),
+                            size: 24
+                        )
+                    }
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+            }
+            .buttonStyle(.plain)
+
+            // Expanded content
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 0) {
+                    if let usage = result.usage {
+                        if let limits = usage.quotaLimits.limits, !limits.isEmpty {
+                            QuotaSectionView(quotaData: usage.quotaLimits, accentColor: accentColor)
+                        }
+                        if usage.modelUsage.totalUsage != nil || usage.toolUsage.totalUsage != nil {
+                            StatsSectionView(usage: usage, accentColor: accentColor)
+                        }
+                    } else if let error = result.error {
+                        Text(error)
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                            .lineLimit(3)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                    }
+                }
+            }
+        }
+        .background(Color.primary.opacity(0.05))
+        .cornerRadius(10)
+    }
+}
+```
+
+This won't compile yet — `QuotaSectionView` and `StatsSectionView` are added in the next tasks.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
+git commit -m "wip: redesign AccountSectionView header with ring and level badge"
+```
+
+---
+
+### Task 6: Add QuotaSectionView (Inline Quota Bars)
+
+**Files:**
+- Modify: `ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift`
+
+This replaces `QuotaLimitsView` and `QuotaLimitRow` with a simpler inline version that renders directly inside the account card.
+
+- [ ] **Step 1: Add QuotaSectionView**
+
+Remove the old `QuotaLimitsView` and `QuotaLimitRow` structs. Replace with:
+
+```swift
+struct QuotaSectionView: View {
+    let quotaData: QuotaLimitData
+    let accentColor: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if let limits = quotaData.limits, !limits.isEmpty {
+                ForEach(Array(limits.enumerated()), id: \.offset) { _, limit in
+                    QuotaBarRow(limit: limit, accentColor: accentColor)
+                }
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+    }
+}
+
+private struct QuotaBarRow: View {
+    let limit: QuotaLimit
+    let accentColor: Color
+
+    private var label: String {
+        if limit.type == "TOKENS_LIMIT" {
+            return limit.unit == 6 ? L10n.localized("weekly_token_label") : L10n.localized("token_label")
+        }
+        if limit.type == "TIME_LIMIT" { return L10n.localized("mcp_label") }
+        return limit.type ?? ""
+    }
+
+    private var resetDate: Date? {
+        guard let t = limit.nextResetTime else { return nil }
+        return Date(timeIntervalSince1970: t / 1000)
+    }
+
+    var body: some View {
+        let color = progressColor(for: limit.percentage, accountAccent: accentColor)
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(label)
+                    .font(.system(size: 9))
+                    .foregroundColor(.secondary.opacity(0.7))
+                Spacer()
+                if let current = limit.currentValue, let usage = limit.usage {
+                    Text(String(format: "%.0f/%.0f", current, usage))
+                        .font(.system(size: 9))
+                        .foregroundColor(.secondary.opacity(0.5))
+                }
+            }
+
+            if let pct = limit.percentage {
+                ProgressView(value: min(pct, 100), total: 100)
+                    .progressViewStyle(LinearProgressViewStyle(tint: color))
+                    .frame(height: 3)
+            }
+
+            if let resetDate = resetDate {
+                HStack {
+                    Spacer()
+                    Text("\(L10n.localized("resets_prefix")) \(resetDate, style: .relative)")
+                        .font(.system(size: 8))
+                        .foregroundColor(.secondary.opacity(0.4))
+                }
+            }
+        }
+        .padding(.bottom, 2)
+    }
+}
+```
+
+Note: The old `QuotaLimitsView` had a wrapping card with background/padding and a "Quota" section header. The new `QuotaSectionView` renders quota bars inline without a separate header — they live directly inside the account card.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
+git commit -m "feat: add QuotaSectionView with inline quota bars"
+```
+
+---
+
+### Task 7: Add StatsSectionView (Compact Stats + Tool Breakdown)
+
+**Files:**
+- Modify: `ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift`
+
+This replaces the separate `ModelUsageView` and `ToolUsageView` with a single compact stats section.
+
+- [ ] **Step 1: Add StatsSectionView**
+
+Remove the old `ModelUsageView` and `ToolUsageView` structs. Add:
+
+```swift
+struct StatsSectionView: View {
+    let usage: UsageData
+    let accentColor: Color
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Divider()
+                .background(Color.primary.opacity(0.05))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+
+            // Main stats row
+            HStack(spacing: 0) {
+                if let calls = usage.modelUsage.totalUsage?.totalModelCallCount {
+                    StatColumn(value: "\(calls)", label: "Model Calls")
+                    Spacer()
+                }
+                if let totalTools = usage.toolUsage.totalUsage?.totalSearchMcpCount {
+                    StatColumn(value: "\(totalTools)", label: "Tool Calls")
+                    Spacer()
+                }
+                if let tokens = usage.modelUsage.totalUsage?.totalTokensUsage {
+                    StatColumn(value: formatTokenCount(tokens), label: "Tokens")
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.bottom, 6)
+
+            // Tool breakdown
+            if let details = usage.toolUsage.totalUsage?.toolDetails, !details.isEmpty {
+                VStack(spacing: 2) {
+                    ForEach(details, id: \.self) { detail in
+                        HStack {
+                            Text(detail.modelName ?? "")
+                                .font(.system(size: 9))
+                                .foregroundColor(.primary.opacity(0.35))
+                            Spacer()
+                            Text("\(detail.totalUsageCount ?? 0)")
+                                .font(.system(size: 9))
+                                .fontWeight(.medium)
+                                .foregroundColor(.primary.opacity(0.45))
+                        }
+                    }
+                }
+                .padding(.horizontal, 10)
+                .padding(.bottom, 8)
+            }
+        }
+    }
+}
+
+private struct StatColumn: View {
+    let value: String
+    let label: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(value)
+                .font(.system(size: 15, weight: .bold))
+                .foregroundColor(.primary.opacity(0.9))
+            Text(label)
+                .font(.system(size: 8))
+                .foregroundColor(.primary.opacity(0.3))
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
+git commit -m "feat: add StatsSectionView with compact stats and tool breakdown"
+```
+
+---
+
+### Task 8: Update MenuBarContentView to Pass colorIndex
+
+**Files:**
+- Modify: `ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift`
+
+- [ ] **Step 1: Update the ForEach to pass colorIndex**
+
+In `MenuBarContentView.body`, change the `ForEach` call:
+
+From:
+```swift
+ForEach(dashboard.accounts) { result in
+    AccountSectionView(
+        result: result,
+        isExpanded: expandedAccounts.contains(result.id),
+        onToggle: { toggleAccount(result.id) }
+    )
+}
+```
+
+To:
+```swift
+ForEach(Array(dashboard.accounts.enumerated()), id: \.element.id) { index, result in
+    AccountSectionView(
+        result: result,
+        colorIndex: index,
+        isExpanded: expandedAccounts.contains(result.id),
+        onToggle: { toggleAccount(result.id) }
+    )
+}
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cd /Users/benjamin/tools/zai_usage_menu_bar/ZaiUsageMenuBar && swift build 2>&1 | tail -20`
+Expected: BUILD SUCCEEDED
+
+If there are compile errors from leftover references to old views (`QuotaLimitsView`, `ModelUsageView`, `ToolUsageView`, or the old `progressColor(for:)` signature), fix them now.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
+git commit -m "feat: wire up colorIndex to AccountSectionView"
+```
+
+---
+
+### Task 9: Update Background to Native Window Color
+
+**Files:**
+- Modify: `ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift`
+- Modify: `ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/AppDelegate.swift`
+
+- [ ] **Step 1: Set native popover appearance**
+
+In `AppDelegate.applicationDidFinishLaunching`, after `popover.behavior = .transient`, add:
+
+```swift
+popover.appearance = NSAppearance(named: .darkAqua)
+```
+
+This ensures the popover always uses dark mode styling matching the design.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/AppDelegate.swift
+git commit -m "feat: set popover to dark aqua appearance"
+```
+
+---
+
+### Task 10: Final Build and Manual Testing
+
+**Files:** None
+
+- [ ] **Step 1: Full build**
+
+Run: `cd /Users/benjamin/tools/zai_usage_menu_bar/ZaiUsageMenuBar && swift build -c release 2>&1 | tail -20`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 2: Run the app manually**
+
+Run: `open /Users/benjamin/tools/zai_usage_menu_bar/ZaiUsageMenuBar/.build/arm64-apple-macosx/release/ZaiUsageMenuBar.app`
+
+Manual checks:
+- Click menu bar item — popover opens
+- Account card shows with circular ring in header
+- Level badge (PRO etc.) appears in header if present
+- Both 5h and weekly quota bars show (if data has both)
+- Stats row shows Model Calls, Tool Calls, Tokens in large bold
+- Tool breakdown shows if toolDetails exist
+- Click header to collapse/expand — ring stays visible when collapsed
+- Multiple accounts have different system colors (blue, orange, green, etc.)
+- Danger colors override at >=70% and >=90%
+- Refresh button works
+- Settings sheet opens
+- ZAI logo loads in header (or fallback "Z" if offline)

--- a/docs/superpowers/specs/2026-04-09-native-ui-redesign.md
+++ b/docs/superpowers/specs/2026-04-09-native-ui-redesign.md
@@ -1,0 +1,134 @@
+# Native UI Redesign
+
+## Goal
+
+Redesign the menu bar app UI to use a native macOS visual style with Apple system colors, circular progress rings for account identification, and compact stat rows — replacing the current plain card layout.
+
+## Visual Identity
+
+- **Width:** 300px (unchanged)
+- **Background:** macOS native dark window background (`Color(nsColor: .windowBackgroundColor)`)
+- **Cards:** Subtle translucent backgrounds (`rgba(255,255,255,0.05)`), 10px corner radius, no gradient accent bars
+- **Account identification:** Small circular progress ring next to account name showing token usage percentage
+- **Typography:** Apple system font. Large bold stats (15pt, weight 700) with small muted labels (8pt)
+- **Progress bars:** Horizontal bars tinted with account's assigned system color; danger overrides at thresholds (orange >= 70%, red >= 90%)
+
+## Card Structure
+
+### Expanded
+
+```
+▼ 主账号                 PRO    [ring 10%]
+  Tokens (5h)            10K / 100K
+  [========                            ]
+  2h 30m 后重置
+
+  Tokens (周)            50K / 500K     ← only if weekly data exists
+  [========                            ]
+  3d 12h 后重置
+
+  ─────────────────────────────────────
+  1,234          567           89.2K
+  Model Calls    Tool Calls    Tokens
+
+  Web Search ................ 234
+  MCP Reads ................. 189       ← only if toolDetails non-empty
+```
+
+### Collapsed
+
+```
+▶ 工作账号                        [ring 75%]
+```
+
+- Both 5h and weekly quota bars shown when data exists (unit == 6 means weekly)
+- Level badge (e.g. "PRO") moved from quota section header into the account header row
+- Reset timer shown below each progress bar
+- Stats row: 3 compact columns — large number, small label below
+- Tool breakdown: label-value rows, only when toolDetails is non-empty
+- Collapsed: chevron + name + mini ring only
+
+### Progress Ring
+
+- Shows 5h window token percentage (most actionable short-term metric)
+- 5h limit identified by: `type == "TOKENS_LIMIT"` where `unit != 6` (or unit is nil)
+- Falls back to weekly percentage (`unit == 6`) if no 5h data
+- Drawn with SwiftUI `Circle` + `trim` stroke — small inline size (~24pt)
+- Tinted with account's assigned system color (danger thresholds override)
+
+## Header Bar
+
+```
+[ZAI Logo]  ZAI Usage               09:42  ↻  ⚙  ✕
+```
+
+- App icon: official ZAI logo from `https://z-cdn.chatglm.cn/z-ai/static/logo.svg` (download as asset)
+- SF Symbol buttons for refresh, settings, quit — subtle low opacity
+
+## Account Color Assignment
+
+Fixed palette cycling through Apple system colors:
+
+| Account # | Color     | Hex       |
+|-----------|-----------|-----------|
+| 1         | Blue      | #0a84ff   |
+| 2         | Orange    | #ff9f0a   |
+| 3         | Green     | #30d158   |
+| 4         | Purple    | #5e5ce6   |
+| 5         | Cyan      | #64d2ff   |
+| 6         | Pink      | #ff375f   |
+
+Ring, percentage text, and progress bar tint all use the account's assigned color.
+
+Danger override: if percentage >= 70%, use system orange (#ff9f0a); >= 90%, use system red (#ff453a). This overrides the account color for progress bars and ring fill.
+
+## Interactions
+
+- Tap card header → toggle expand/collapse
+- All accounts expanded by default
+- On first load, expand all (current behavior)
+- Refresh → reloads all accounts
+- Loading: compact ProgressView below cards
+- Error: per-account inline error in expanded view
+
+## Changes Required
+
+### MenuBarContentView.swift
+
+- Remove gradient accent bars from `AccountSectionView`
+- Add circular progress ring component to account header (replacing text percentage)
+- Add `accountColor(for: Int)` helper returning system colors from the palette
+- Add `ringPercentage(from: QuotaLimitData)` helper — returns 5h limit percentage, falls back to weekly
+  - 5h limit = first `QuotaLimit` where `type == "TOKENS_LIMIT"` and `unit != 6`
+  - Weekly = first where `unit == 6`
+- Move level badge from `QuotaLimitsView` into account header row
+- Remove `QuotaLimitsView` as a wrapping section — render `QuotaLimitRow`s directly inside `AccountSectionView`
+- Restyle `QuotaLimitRow`: progress bars use account color tint
+- Remove `ModelUsageView` and `ToolUsageView` as separate sections
+- Add compact stats row: 3 columns (Model Calls / Tool Calls / Total Tokens) with large bold numbers
+- Add tool breakdown rows below stats (only when toolDetails exist)
+- Update card backgrounds to `rgba(255,255,255,0.05)`, 10px radius
+- Update overall background to native window color
+
+### Assets
+
+- Download ZAI logo SVG from `https://z-cdn.chatglm.cn/z-ai/static/logo.svg`
+- Add to asset catalog as the header app icon
+
+### UsageViewModel.swift / UsageModels.swift
+
+- No structural changes needed — existing data models provide all required fields
+
+### Localization.swift
+
+- No new keys needed — existing labels suffice
+
+## Testing
+
+- Verify circular ring renders correctly at 0%, 50%, 100%+ (capped display)
+- Verify 5h ring percentage, weekly fallback when no 5h data
+- Verify danger color override at 70% and 90% thresholds
+- Verify both quota bars show when weekly data present, single bar when only 5h
+- Verify collapsed/expanded toggle
+- Verify multiple accounts get distinct system colors
+- Verify level badge appears in account header when present


### PR DESCRIPTION
## Summary

Redesign the menu bar app UI with a native macOS aesthetic:

- **TokenRingView** — circular progress ring per account showing 5h token usage (with weekly fallback)
- **Apple system colors** — 6-color palette cycling per account (blue, orange, green, purple, cyan, pink)
- **Compact inline layout** — quota bars, stats (Model Calls / Tool Calls / Tokens), and tool breakdown all rendered inside each account card
- **Level badge** moved from quota section into account header
- **ZAI logo** loaded via AsyncImage in header
- **Dark aqua** popover appearance for consistent dark theme
- **Keychain fix** — suppress repeated prompts by using `kSecUseAuthenticationUIFail` and `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`
- **Build script fix** — `--keychain` flag in codesign to avoid repeated unlock prompts

## Screenshots

<img src="https://z-cdn.chatglm.cn/z-ai/static/logo.svg" width="16" style="vertical-align:middle"> Native dark theme with ring indicators and compact stat rows.

## Test plan

- [x] Release build passes
- [x] All 10 existing tests pass (including 3 new ringPercentage tests)
- [ ] Manual: circular ring renders at various percentages
- [ ] Manual: 5h and weekly quota bars both show when present
- [ ] Manual: level badge appears in account header
- [ ] Manual: multiple accounts get distinct system colors
- [ ] Manual: danger color override at >=70% and >=90%
- [ ] Manual: no keychain prompts on subsequent launches