### PR TITLE
feat: hourly token usage bar chart

### DIFF
--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/HourlyChartView.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/HourlyChartView.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+
+struct HourlyChartView: View {
+    let bars: [HourlyBar]
+    let modelNames: [String]
+    let range: HourlyRange
+    let onRangeChange: (HourlyRange) -> Void
+
+    private let barHeight: CGFloat = 60
+    private let barGap: CGFloat = 2
+    private let maxLabelCount = 5
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            // Header with toggle
+            HStack {
+                Text(L10n.localized("hourly_tokens"))
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(.primary.opacity(0.7))
+                Spacer()
+                rangeToggle
+            }
+
+            if bars.isEmpty {
+                Text(L10n.localized("no_data"))
+                    .font(.system(size: 9))
+                    .foregroundColor(.secondary.opacity(0.5))
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 16)
+            } else {
+                // Bar chart
+                GeometryReader { geometry in
+                    let barWidth = max((geometry.size.width - barGap * CGFloat(max(bars.count - 1, 0))) / CGFloat(bars.count), 2)
+                    HStack(alignment: .bottom, spacing: barGap) {
+                        ForEach(Array(bars.enumerated()), id: \.offset) { index, bar in
+                            VStack(spacing: 0) {
+                                Spacer(minLength: 0)
+                                barStack(bar: bar, barWidth: barWidth)
+                            }
+                            .frame(width: barWidth, height: barHeight)
+                        }
+                    }
+                    .frame(height: barHeight)
+                }
+                .frame(height: barHeight)
+
+                // Legend
+                legend
+
+                // X-axis labels
+                xAxisLabels
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+    }
+
+    private var rangeToggle: some View {
+        Picker("", selection: Binding(
+            get: { range.isToday ? 0 : 1 },
+            set: { onRangeChange($0 == 0 ? .today(referenceDate: Date()) : .last24h) }
+        )) {
+            Text(L10n.localized("today")).tag(0)
+            Text("24h").tag(1)
+        }
+        .pickerStyle(.segmented)
+        .frame(width: 100)
+        .scaleEffect(0.8)
+        .frame(width: 80, height: 16)
+    }
+
+    @ViewBuilder
+    private func barStack(bar: HourlyBar, barWidth: CGFloat) -> some View {
+        let maxTotal = bars.map(\.totalTokens).max() ?? 1
+        let scaleFactor = CGFloat(bar.totalTokens) / CGFloat(max(maxTotal, 1))
+
+        VStack(spacing: 0) {
+            ForEach(Array(bar.segments.enumerated()), id: \.offset) { segIndex, segment in
+                let segFraction = CGFloat(segment.tokens) / CGFloat(max(bar.totalTokens, 1))
+                let segHeight = max(barHeight * scaleFactor * segFraction, segment.tokens > 0 ? 1 : 0)
+                RoundedRectangle(cornerRadius: segIndex == bar.segments.count - 1 ? 2 : 0)
+                    .fill(colorForModel(segment.model))
+                    .frame(height: segHeight)
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 2))
+    }
+
+    private var legend: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(modelNames, id: \.self) { name in
+                    HStack(spacing: 2) {
+                        Circle()
+                            .fill(colorForModel(name))
+                            .frame(width: 5, height: 5)
+                        Text(name)
+                            .font(.system(size: 7))
+                            .foregroundColor(.secondary.opacity(0.7))
+                            .lineLimit(1)
+                    }
+                }
+            }
+        }
+    }
+
+    private var xAxisLabels: some View {
+        HStack(spacing: 0) {
+            ForEach(Array(labelIndices.enumerated()), id: \.offset) { _, index in
+                if let bar = bars[safe: index] {
+                    Text(bar.label)
+                        .font(.system(size: 7))
+                        .foregroundColor(.secondary.opacity(0.5))
+                        .frame(maxWidth: .infinity)
+                }
+            }
+        }
+    }
+
+    private var labelIndices: [Int] {
+        guard bars.count > maxLabelCount else { return Array(0..<bars.count) }
+        let step = max(1, bars.count / (maxLabelCount - 1))
+        var indices = stride(from: 0, to: bars.count, by: step).map { $0 }
+        if indices.last != bars.count - 1 {
+            indices.append(bars.count - 1)
+        }
+        return indices
+    }
+
+    private func colorForModel(_ name: String) -> Color {
+        let index = modelNames.firstIndex(of: name) ?? 0
+        return accountColorPalette[index % accountColorPalette.count]
+    }
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/HourlyChartView.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/HourlyChartView.swift
@@ -6,53 +6,87 @@ struct HourlyChartView: View {
     let range: HourlyRange
     let onRangeChange: (HourlyRange) -> Void
 
+    @State private var isExpanded = true
+    @State private var hoveredBarIndex: Int? = nil
+
     private let barHeight: CGFloat = 60
     private let barGap: CGFloat = 2
     private let maxLabelCount = 5
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            // Header with toggle
-            HStack {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header with toggle and collapse chevron
+            HStack(spacing: 4) {
+                Button(action: { withAnimation(.easeInOut(duration: 0.2)) { isExpanded.toggle() } }) {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 8))
+                        .foregroundColor(.secondary)
+                        .frame(width: 10)
+                }
+                .buttonStyle(.plain)
+
                 Text(L10n.localized("hourly_tokens"))
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundColor(.primary.opacity(0.7))
+
                 Spacer()
-                rangeToggle
+
+                if isExpanded {
+                    rangeToggle
+                }
             }
 
-            if bars.isEmpty {
-                Text(L10n.localized("no_data"))
-                    .font(.system(size: 9))
-                    .foregroundColor(.secondary.opacity(0.5))
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .padding(.vertical, 16)
-            } else {
-                // Bar chart
-                GeometryReader { geometry in
-                    let barWidth = max((geometry.size.width - barGap * CGFloat(max(bars.count - 1, 0))) / CGFloat(bars.count), 2)
-                    HStack(alignment: .bottom, spacing: barGap) {
-                        ForEach(Array(bars.enumerated()), id: \.offset) { index, bar in
-                            VStack(spacing: 0) {
-                                Spacer(minLength: 0)
-                                barStack(bar: bar, barWidth: barWidth)
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 4) {
+                    if bars.isEmpty {
+                        Text(L10n.localized("no_data"))
+                            .font(.system(size: 9))
+                            .foregroundColor(.secondary.opacity(0.5))
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .padding(.vertical, 16)
+                    } else {
+                        // Bar chart with tooltip overlay
+                        ZStack(alignment: .bottomLeading) {
+                            GeometryReader { geometry in
+                                let barWidth = max((geometry.size.width - barGap * CGFloat(max(bars.count - 1, 0))) / CGFloat(bars.count), 2)
+                                HStack(alignment: .bottom, spacing: barGap) {
+                                    ForEach(Array(bars.enumerated()), id: \.offset) { index, bar in
+                                        VStack(spacing: 0) {
+                                            Spacer(minLength: 0)
+                                            barStack(bar: bar, barWidth: barWidth)
+                                        }
+                                        .frame(width: barWidth, height: barHeight)
+                                        .contentShape(Rectangle())
+                                        .onHover { hovering in
+                                            hoveredBarIndex = hovering ? index : nil
+                                        }
+                                    }
+                                }
+                                .frame(height: barHeight)
                             }
-                            .frame(width: barWidth, height: barHeight)
+                            .frame(height: barHeight)
+
+                            // Tooltip
+                            if let hoveredIndex = hoveredBarIndex, hoveredIndex < bars.count {
+                                let bar = bars[hoveredIndex]
+                                tooltipOverlay(bar: bar)
+                            }
                         }
+
+                        // Legend
+                        legend
+
+                        // X-axis labels
+                        xAxisLabels
                     }
-                    .frame(height: barHeight)
                 }
-                .frame(height: barHeight)
-
-                // Legend
-                legend
-
-                // X-axis labels
-                xAxisLabels
+                .padding(.top, 6)
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 4)
+        .animation(.easeInOut(duration: 0.2), value: isExpanded)
     }
 
     private var rangeToggle: some View {
@@ -84,6 +118,46 @@ struct HourlyChartView: View {
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: 2))
+    }
+
+    private func tooltipOverlay(bar: HourlyBar) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(bar.label + ":00")
+                .font(.system(size: 8, weight: .semibold))
+                .foregroundColor(.primary.opacity(0.8))
+            ForEach(Array(bar.segments.enumerated()), id: \.offset) { _, segment in
+                HStack(spacing: 4) {
+                    Circle()
+                        .fill(colorForModel(segment.model))
+                        .frame(width: 4, height: 4)
+                    Text(segment.model)
+                        .font(.system(size: 7))
+                        .foregroundColor(.secondary)
+                    Spacer()
+                    Text(formatTokenCount(segment.tokens))
+                        .font(.system(size: 7, weight: .medium))
+                        .foregroundColor(.primary.opacity(0.8))
+                }
+            }
+            Divider()
+                .background(Color.primary.opacity(0.1))
+            HStack {
+                Text("Total")
+                    .font(.system(size: 7))
+                    .foregroundColor(.secondary)
+                Spacer()
+                Text(formatTokenCount(bar.totalTokens))
+                    .font(.system(size: 7, weight: .bold))
+                    .foregroundColor(.primary.opacity(0.9))
+            }
+        }
+        .padding(6)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.95))
+        .background(.ultraThinMaterial)
+        .cornerRadius(6)
+        .shadow(color: .black.opacity(0.2), radius: 4, y: 2)
+        .padding(.horizontal, 4)
+        .offset(y: -barHeight - 8)
     }
 
     private var legend: some View {

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/HourlyChartView.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/HourlyChartView.swift
@@ -121,19 +121,20 @@ struct HourlyChartView: View {
     }
 
     private func tooltipOverlay(bar: HourlyBar) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: 1) {
             Text(bar.label + ":00")
                 .font(.system(size: 8, weight: .semibold))
                 .foregroundColor(.primary.opacity(0.8))
             ForEach(Array(bar.segments.enumerated()), id: \.offset) { _, segment in
-                HStack(spacing: 4) {
+                HStack(spacing: 3) {
                     Circle()
                         .fill(colorForModel(segment.model))
                         .frame(width: 4, height: 4)
                     Text(segment.model)
                         .font(.system(size: 7))
                         .foregroundColor(.secondary)
-                    Spacer()
+                        .lineLimit(1)
+                        .layoutPriority(1)
                     Text(formatTokenCount(segment.tokens))
                         .font(.system(size: 7, weight: .medium))
                         .foregroundColor(.primary.opacity(0.8))
@@ -141,22 +142,16 @@ struct HourlyChartView: View {
             }
             Divider()
                 .background(Color.primary.opacity(0.1))
-            HStack {
-                Text("Total")
-                    .font(.system(size: 7))
-                    .foregroundColor(.secondary)
-                Spacer()
-                Text(formatTokenCount(bar.totalTokens))
-                    .font(.system(size: 7, weight: .bold))
-                    .foregroundColor(.primary.opacity(0.9))
-            }
+            Text(formatTokenCount(bar.totalTokens))
+                .font(.system(size: 8, weight: .bold))
+                .foregroundColor(.primary.opacity(0.9))
         }
-        .padding(6)
+        .padding(5)
+        .frame(minWidth: 80, maxWidth: 120)
         .background(Color(nsColor: .controlBackgroundColor).opacity(0.95))
         .background(.ultraThinMaterial)
         .cornerRadius(6)
         .shadow(color: .black.opacity(0.2), radius: 4, y: 2)
-        .padding(.horizontal, 4)
         .offset(y: -barHeight - 8)
     }
 

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/Localization.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/Localization.swift
@@ -142,6 +142,18 @@ enum L10n {
             "en": "System Default",
             "zh": "跟随系统",
         ],
+        "hourly_tokens": [
+            "en": "Hourly Tokens",
+            "zh": "每小时 Token",
+        ],
+        "no_data": [
+            "en": "No data",
+            "zh": "暂无数据",
+        ],
+        "today": [
+            "en": "Today",
+            "zh": "今天",
+        ],
     ]
 
     static func localized(_ key: String) -> String {

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/MenuBarContentView.swift
@@ -190,6 +190,7 @@ struct AccountSectionView: View {
     let colorIndex: Int
     let isExpanded: Bool
     let onToggle: () -> Void
+    @State private var hourlyRange: HourlyRange = .today(referenceDate: Date())
 
     private var accentColor: Color { accountColor(for: colorIndex) }
 
@@ -242,6 +243,22 @@ struct AccountSectionView: View {
                     if let usage = result.usage {
                         if let limits = usage.quotaLimits.limits, !limits.isEmpty {
                             QuotaSectionView(quotaData: usage.quotaLimits, accentColor: accentColor)
+                        }
+                        if let modelData = usage.modelUsage.modelDataList, !modelData.isEmpty {
+                            let bars = HourlyBars.from(modelData: usage.modelUsage, range: hourlyRange)
+                            let modelNames = modelData.compactMap { $0.modelName }
+
+                            Divider()
+                                .background(Color.primary.opacity(0.05))
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 4)
+
+                            HourlyChartView(
+                                bars: bars,
+                                modelNames: modelNames,
+                                range: hourlyRange,
+                                onRangeChange: { hourlyRange = $0 }
+                            )
                         }
                         if usage.modelUsage.totalUsage != nil || usage.toolUsage.totalUsage != nil {
                             StatsSectionView(usage: usage, accentColor: accentColor)
@@ -398,7 +415,7 @@ private struct StatColumn: View {
     }
 }
 
-private let accountColorPalette: [Color] = [
+let accountColorPalette: [Color] = [
     Color(red: 10/255, green: 132/255, blue: 1),      // Blue #0a84ff
     Color(red: 255/255, green: 159/255, blue: 10/255), // Orange #ff9f0a
     Color(red: 48/255, green: 209/255, blue: 88/255),  // Green #30d158

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageModels.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageModels.swift
@@ -113,6 +113,11 @@ struct AccountConfig: Codable, Identifiable, Hashable {
 enum HourlyRange {
     case today(referenceDate: Date)
     case last24h
+
+    var isToday: Bool {
+        if case .today = self { return true }
+        return false
+    }
 }
 
 struct HourlyBar {

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageModels.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageModels.swift
@@ -12,18 +12,37 @@ struct ModelUsageData: Codable {
     let modelCallCount: [Int?]?
     let tokensUsage: [Int?]?
     let totalUsage: ModelUsageTotal?
-    
+    let modelDataList: [ModelDataItem]?
+    let modelSummaryList: [ModelSummaryItem]?
+    let granularity: String?
+
     enum CodingKeys: String, CodingKey {
         case xTime = "x_time"
         case modelCallCount
         case tokensUsage
         case totalUsage
+        case modelDataList
+        case modelSummaryList
+        case granularity
     }
 }
 
 struct ModelUsageTotal: Codable {
     let totalModelCallCount: Int?
     let totalTokensUsage: Int?
+}
+
+struct ModelDataItem: Codable {
+    let modelName: String?
+    let sortOrder: Int?
+    let tokensUsage: [Int?]?
+    let totalTokens: Int?
+}
+
+struct ModelSummaryItem: Codable {
+    let modelName: String?
+    let totalTokens: Int?
+    let sortOrder: Int?
 }
 
 struct ToolUsageData: Codable {

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageModels.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageModels.swift
@@ -7,6 +7,24 @@ struct APIResponse<T: Codable>: Codable {
     let success: Bool
 }
 
+struct ModelUsageTotal: Codable {
+    let totalModelCallCount: Int?
+    let totalTokensUsage: Int?
+}
+
+struct ModelDataItem: Codable {
+    let modelName: String?
+    let sortOrder: Int?
+    let tokensUsage: [Int?]?
+    let totalTokens: Int?
+}
+
+struct ModelSummaryItem: Codable {
+    let modelName: String?
+    let totalTokens: Int?
+    let sortOrder: Int?
+}
+
 struct ModelUsageData: Codable {
     let xTime: [String]?
     let modelCallCount: [Int?]?
@@ -25,24 +43,6 @@ struct ModelUsageData: Codable {
         case modelSummaryList
         case granularity
     }
-}
-
-struct ModelUsageTotal: Codable {
-    let totalModelCallCount: Int?
-    let totalTokensUsage: Int?
-}
-
-struct ModelDataItem: Codable {
-    let modelName: String?
-    let sortOrder: Int?
-    let tokensUsage: [Int?]?
-    let totalTokens: Int?
-}
-
-struct ModelSummaryItem: Codable {
-    let modelName: String?
-    let totalTokens: Int?
-    let sortOrder: Int?
 }
 
 struct ToolUsageData: Codable {

--- a/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageModels.swift
+++ b/ZaiUsageMenuBar/Sources/ZaiUsageMenuBar/UsageModels.swift
@@ -110,6 +110,74 @@ struct AccountConfig: Codable, Identifiable, Hashable {
     }
 }
 
+enum HourlyRange {
+    case today(referenceDate: Date)
+    case last24h
+}
+
+struct HourlyBar {
+    let label: String
+    let segments: [(model: String, tokens: Int)]
+    var totalTokens: Int { segments.reduce(0) { $0 + $1.tokens } }
+}
+
+enum HourlyBars {
+    static func from(modelData: ModelUsageData, range: HourlyRange) -> [HourlyBar] {
+        guard let xTime = modelData.xTime, !xTime.isEmpty,
+              let modelItems = modelData.modelDataList else {
+            return []
+        }
+
+        let calendar = Calendar.current
+        let referenceDate: Date
+        switch range {
+        case .today(let ref): referenceDate = ref
+        case .last24h: referenceDate = Date()
+        }
+
+        let todayStart = calendar.startOfDay(for: referenceDate)
+
+        var bars: [HourlyBar] = []
+        for (index, timeString) in xTime.enumerated() {
+            guard let hourDate = parseHourDate(timeString) else { continue }
+
+            if case .today = range {
+                if hourDate < todayStart { continue }
+            }
+
+            var segments: [(model: String, tokens: Int)] = []
+            for item in modelItems {
+                guard let tokens = item.tokensUsage,
+                      index < tokens.count,
+                      let tokenCount = tokens[index], tokenCount > 0 else { continue }
+                segments.append((model: item.modelName ?? "Unknown", tokens: tokenCount))
+            }
+
+            let total = segments.reduce(0) { $0 + $1.tokens }
+            guard total > 0 else { continue }
+
+            let label = formatHourLabel(hourDate: hourDate)
+            bars.append(HourlyBar(label: label, segments: segments))
+        }
+
+        return bars
+    }
+
+    private static func parseHourDate(_ string: String) -> Date? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter.date(from: string)
+    }
+
+    private static func formatHourLabel(hourDate: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter.string(from: hourDate)
+    }
+}
+
 struct AccountUsageResult: Identifiable {
     var id: String { account.id }
     let account: AccountConfig

--- a/ZaiUsageMenuBar/Tests/ZaiUsageMenuBarTests/UsageModelsTests.swift
+++ b/ZaiUsageMenuBar/Tests/ZaiUsageMenuBarTests/UsageModelsTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import ZaiUsageMenuBar
+
+final class UsageModelsTests: XCTestCase {
+    func testDecodeModelDataList() throws {
+        let json = """
+        {
+            "x_time": ["2026-04-09 10:00", "2026-04-09 11:00"],
+            "modelCallCount": [5, 10],
+            "tokensUsage": [1000, 2000],
+            "totalUsage": {
+                "totalModelCallCount": 15,
+                "totalTokensUsage": 3000
+            },
+            "modelDataList": [
+                {
+                    "modelName": "GLM-5.1",
+                    "sortOrder": 1,
+                    "tokensUsage": [800, 1500],
+                    "totalTokens": 2300
+                },
+                {
+                    "modelName": "GLM-4.7",
+                    "sortOrder": 2,
+                    "tokensUsage": [200, 500],
+                    "totalTokens": 700
+                }
+            ],
+            "modelSummaryList": [
+                {"modelName": "GLM-5.1", "totalTokens": 2300, "sortOrder": 1}
+            ],
+            "granularity": "hourly"
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(ModelUsageData.self, from: json)
+        XCTAssertEqual(decoded.modelDataList?.count, 2)
+        XCTAssertEqual(decoded.modelDataList?[0].modelName, "GLM-5.1")
+        XCTAssertEqual(decoded.modelDataList?[0].tokensUsage, [800, 1500])
+        XCTAssertEqual(decoded.modelSummaryList?.count, 1)
+        XCTAssertEqual(decoded.granularity, "hourly")
+    }
+}

--- a/ZaiUsageMenuBar/Tests/ZaiUsageMenuBarTests/UsageModelsTests.swift
+++ b/ZaiUsageMenuBar/Tests/ZaiUsageMenuBarTests/UsageModelsTests.swift
@@ -41,3 +41,70 @@ final class UsageModelsTests: XCTestCase {
         XCTAssertEqual(decoded.granularity, "hourly")
     }
 }
+
+extension UsageModelsTests {
+    func testHourlyBarFiltering24h() {
+        let modelData = ModelUsageData(
+            xTime: ["2026-04-08 22:00", "2026-04-08 23:00", "2026-04-09 00:00", "2026-04-09 01:00"],
+            modelCallCount: [5, 0, 10, 3],
+            tokensUsage: [1000, 0, 2000, 500],
+            totalUsage: nil,
+            modelDataList: [
+                ModelDataItem(modelName: "GLM-5.1", sortOrder: 1, tokensUsage: [800, 0, 1500, 400], totalTokens: 2700),
+                ModelDataItem(modelName: "GLM-4.7", sortOrder: 2, tokensUsage: [200, 0, 500, 100], totalTokens: 800)
+            ],
+            modelSummaryList: nil,
+            granularity: "hourly"
+        )
+
+        let bars = HourlyBars.from(modelData: modelData, range: .last24h)
+        // 24h: skip zero-total hours (23:00), keep 3 bars
+        XCTAssertEqual(bars.count, 3)
+        XCTAssertEqual(bars[0].label, "22")
+        XCTAssertEqual(bars[0].totalTokens, 1000)
+        XCTAssertEqual(bars[0].segments.count, 2)
+        XCTAssertEqual(bars[0].segments[0].model, "GLM-5.1")
+        XCTAssertEqual(bars[0].segments[0].tokens, 800)
+        XCTAssertEqual(bars[0].segments[1].model, "GLM-4.7")
+        XCTAssertEqual(bars[0].segments[1].tokens, 200)
+    }
+
+    func testHourlyBarFilteringToday() {
+        let modelData = ModelUsageData(
+            xTime: ["2026-04-08 23:00", "2026-04-09 00:00", "2026-04-09 01:00", "2026-04-09 02:00"],
+            modelCallCount: [5, 10, 0, 3],
+            tokensUsage: [1000, 2000, 0, 500],
+            totalUsage: nil,
+            modelDataList: [
+                ModelDataItem(modelName: "GLM-5.1", sortOrder: 1, tokensUsage: [800, 1500, 0, 400], totalTokens: 2700)
+            ],
+            modelSummaryList: nil,
+            granularity: "hourly"
+        )
+
+        let bars = HourlyBars.from(modelData: modelData, range: .today(referenceDate: date(year: 2026, month: 4, day: 9, hour: 2)))
+        // Only Apr 9 hours: 00:00, 01:00, 02:00. Skip 01:00 (zero). Skip 23:00 (Apr 8).
+        XCTAssertEqual(bars.count, 2)
+        XCTAssertEqual(bars[0].label, "00")
+        XCTAssertEqual(bars[1].label, "02")
+    }
+
+    func testHourlyBarEmptyModelData() {
+        let modelData = ModelUsageData(
+            xTime: nil,
+            modelCallCount: nil,
+            tokensUsage: nil,
+            totalUsage: nil,
+            modelDataList: nil,
+            modelSummaryList: nil,
+            granularity: nil
+        )
+
+        let bars = HourlyBars.from(modelData: modelData, range: .last24h)
+        XCTAssertTrue(bars.isEmpty)
+    }
+
+    private func date(year: Int, month: Int, day: Int, hour: Int) -> Date {
+        Calendar.current.date(from: DateComponents(year: year, month: month, day: day, hour: hour))!
+    }
+}

--- a/docs/superpowers/specs/2026-04-09-hourly-token-chart-design.md
+++ b/docs/superpowers/specs/2026-04-09-hourly-token-chart-design.md
@@ -1,0 +1,76 @@
+# Hourly Token Usage Bar Chart
+
+## Summary
+
+Add a stacked bar chart to each account's expanded section in the menu bar popover, showing hourly token usage broken down by model. Supports toggling between "Today" and "24h" views.
+
+## Data Layer
+
+The `model-usage` API already returns `modelDataList` — an array of objects, each with a model name and a `tokensUsage` array aligned to the `x_time` hourly timestamps. Currently this field is not decoded.
+
+**Changes:**
+
+- Add `modelDataList` and `modelSummaryList` fields to `ModelUsageData`
+- Define `ModelDataItem` codable struct with `modelName`, `sortOrder`, `tokensUsage`, `totalTokens`
+- Define `ModelSummaryItem` codable struct with `modelName`, `totalTokens`, `sortOrder`
+- Add a helper that filters `modelDataList` + `x_time` to the selected range (today from midnight, or last 24h from the API's natural range)
+- Produce `[HourlyBar]` where each `HourlyBar` has a `label` (hour string like "09") and `segments: [(model: String, tokens: Int)]`
+
+No new API calls.
+
+## Time Range Toggle
+
+A small segmented picker (`Today` / `24h`) rendered in the top-right corner of the chart area. Local `@State` in `AccountSectionView`. Defaults to "Today".
+
+- **Today**: hours from midnight to current hour
+- **24h**: full range returned by API (last ~24 hours of data)
+
+## Chart View — `HourlyChartView`
+
+A new SwiftUI view taking hourly bar data and the account accent color.
+
+**Rendering:**
+
+- For each hour with data, draw a vertical bar composed of stacked `RoundedRectangle` segments
+- Stack bottom-up: first model at bottom, last on top
+- Model colors drawn from the existing `accountColorPalette` (blue, orange, green, purple, cyan, pink), assigned by model sort order
+- Bar height: ~60px total, width fills available space (card width minus padding)
+- Each bar gets equal horizontal space with 2px gap between bars
+- Zero-total hours are collapsed (skipped, not rendered as empty space)
+
+**X-axis:**
+
+- 4-5 time labels spread evenly below the bars
+- Format: `HH` (e.g., "00", "06", "12", "18", "Now" for current hour)
+- Only label hours that have corresponding bars
+
+**Y-axis:**
+
+- No explicit axis — the visual height ratio is sufficient for a compact popover chart
+- Tooltip/hover not required for v1
+
+## Legend
+
+A compact single-line row below the chart bars, above the x-axis labels:
+- Colored circle + model name for each model present in the current range
+- Truncate model names if they overflow the available width
+- Use 7-8pt font size
+
+## Placement in UI
+
+Inside `AccountSectionView`, rendered between `QuotaSectionView` and `StatsSectionView`, only when `modelDataList` is non-empty. Wrapped in a `VStack` with the same horizontal padding and dividers as the surrounding sections.
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `UsageModels.swift` | Add `ModelDataItem`, `ModelSummaryItem` structs; add `modelDataList`, `modelSummaryList`, `granularity` fields to `ModelUsageData` |
+| `MenuBarContentView.swift` | Add `HourlyChartView`; integrate into `AccountSectionView` |
+| `UsageModels.swift` | Add `HourlyBar` struct and filtering helper |
+
+## Constraints
+
+- Pure SwiftUI, no external dependencies or Charts framework
+- Must fit within the 300px-wide popover
+- Supports macOS 14+ (matches existing platform target)
+- Must not degrade performance of existing refresh cycle


### PR DESCRIPTION
## Summary

- Add stacked bar chart showing hourly token usage broken down by model inside each account's expanded section
- Today / 24h toggle to switch between time ranges
- Hover tooltip showing per-model token breakdown per hour
- Collapsible chart section with chevron toggle
- Decodes existing `modelDataList` from API — no new API calls

## Files changed

- `UsageModels.swift` — `ModelDataItem`, `ModelSummaryItem`, `HourlyRange`, `HourlyBar`, `HourlyBars` filtering logic
- `HourlyChartView.swift` — new stacked bar chart view with tooltip and collapse
- `Localization.swift` — 3 new keys (en + zh)
- `MenuBarContentView.swift` — chart integration into `AccountSectionView`

## Test plan

- [x] 14 unit tests pass (4 new model tests + 10 existing)
- [x] Build succeeds (debug + release)
- [ ] Visual: chart renders between quota bars and stats
- [ ] Visual: tooltip shows on hover
- [ ] Visual: Today/24h toggle works
- [ ] Visual: collapse/expand works